### PR TITLE
Phase 1: Countries list UI

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/ViewModels/CountriesViewModel.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/ViewModels/CountriesViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  CountriesViewModel.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 26.02.2026.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class CountriesViewModel: ObservableObject {
+    @Published var searchText: String = ""
+    @Published private(set) var countries: [Country] = []
+    
+    private let service = MockCountryService()
+    
+    init() {
+        load()
+    }
+    
+    func load() {
+        countries = service.loadCountries()
+            .sorted { $0.name < $1.name }
+    }
+    
+    var filteredCountries: [Country] {
+        guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return countries
+        }
+        let q = searchText.lowercased()
+        return countries.filter { $0.name.lowercased().contains(q) }
+    }
+    
+    var groupedByContinent: [(continent: Continent, countries: [Country])] {
+        let grouped = Dictionary(grouping: filteredCountries, by: { $0.continent })
+        return Continent.allCases.compactMap { c in
+            guard let items = grouped[c], !items.isEmpty else { return nil }
+            return (c, items.sorted { $0.name < $1.name })
+        }
+    }
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Countries/CountriesScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Countries/CountriesScreen.swift
@@ -9,10 +9,58 @@ import Foundation
 import SwiftUI
 
 struct CountriesScreen: View {
+    @EnvironmentObject private var appState: AppState
+    @StateObject private var vm = CountriesViewModel()
+    
     var body: some View {
         NavigationStack {
-            Text("Countries (Phase 1)")
-                .navigationTitle("Countries")
+            List {
+                ForEach(vm.groupedByContinent, id: \.continent.id) { section in
+                    Section(section.continent.displayName) {
+                        ForEach(section.countries) { country in
+                            CountryRow(
+                                country: country,
+                                isVisited: appState.isVisited(country.id)
+                            ) {
+                                appState.setVisited(country.id, isVisited: !appState.isVisited(country.id))
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Countries")
+            .searchable(text: $vm.searchText, prompt: "Search countries")
         }
+    }
+}
+
+private struct CountryRow: View {
+    let country: Country
+    let isVisited: Bool
+    let onToggle: () -> Void
+    
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 12) {
+                Text(country.flagEmoji)
+                    .font(.title2)
+                
+                Text(country.name)
+                    .foregroundStyle(.primary)
+                
+                Spacer()
+                
+                if isVisited {
+                    Image(systemName: "checkmark.circle.fill")
+                        .imageScale(.large)
+                } else {
+                    Image(systemName: "circle")
+                        .imageScale(.large)
+                        .opacity(0.25)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }


### PR DESCRIPTION
Closes #8

## Included
- Countries list grouped by continent
- Search filter
- Tap to toggle visited using AppState

## How to test
- Run app → Countries tab
- Search
- Tap rows to toggle visited