### PR TITLE
Phase 1: Map placeholder screen

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -5,14 +5,24 @@
 //  Created by seren on 25.02.2026.
 //
 
-import Foundation
 import SwiftUI
 
 struct MapScreen: View {
     var body: some View {
         NavigationStack {
-            Text("Map (Phase 1)")
-                .navigationTitle("Map")
+            VStack(spacing: 12) {
+                Image(systemName: "map")
+                    .font(.system(size: 44))
+                    .foregroundStyle(.secondary)
+
+                Text("Map")
+                    .font(.title).bold()
+
+                Text("Map view will be added in Phase 2.")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle("Map")
         }
     }
 }


### PR DESCRIPTION
Closes #12

## Included
- Map tab now shows a Phase 1 placeholder screen

## How to test
- Run the app
- Tap Map tab -> placeholder is visible
- Verify Countries/Stats tabs still work