### PR TITLE
Phase 1: Stats placeholder screen

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
@@ -5,14 +5,29 @@
 //  Created by seren on 25.02.2026.
 //
 
-import Foundation
 import SwiftUI
 
 struct StatsScreen: View {
+    @EnvironmentObject private var appState: AppState
+
     var body: some View {
         NavigationStack {
-            Text("Stats (Phase 1)")
-                .navigationTitle("Stats")
+            VStack(spacing: 12) {
+                Image(systemName: "chart.bar")
+                    .font(.system(size: 44))
+                    .foregroundStyle(.secondary)
+
+                Text("Stats")
+                    .font(.title).bold()
+
+                Text("Visited countries: \(appState.visitedCount)")
+                    .font(.headline)
+
+                Text("More stats will be added in Phase 2.")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle("Stats")
         }
     }
 }


### PR DESCRIPTION
Closes #14

## Included
- Stats tab shows Phase 1 placeholder UI
- Displays visited countries count from AppState

## How to test
- Run app and open Stats tab
- Mark a country visited in Country Detail
- Return to Stats -> visited count updates