### PR TITLE
Phase 2: Implement VisitRepository for SwiftData

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/SwiftDataVisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/SwiftDataVisitRepository.swift
@@ -1,0 +1,79 @@
+//
+//  SwiftDataVisitRepository.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 2.03.2026.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+final class SwiftDataVisitRepository: VisitRepository {
+    private let context: ModelContext
+
+    init(context: ModelContext) {
+        self.context = context
+    }
+
+    func visit(for countryId: String) throws -> Visit {
+        if let entity = try fetchEntity(countryId: countryId) {
+            return Visit(
+                countryId: entity.countryId,
+                isVisited: entity.isVisited,
+                visitedDate: entity.visitedDate,
+                notes: entity.notes
+            )
+        }
+
+        // default “not visited”
+        return Visit(countryId: countryId, isVisited: false, visitedDate: nil, notes: "")
+    }
+
+    func setVisited(_ countryId: String, isVisited: Bool, visitedDate: Date?) throws {
+        let entity = try fetchOrCreateEntity(countryId: countryId)
+
+        entity.isVisited = isVisited
+
+        if isVisited {
+            // IMPORTANT: allow choosing date; if none provided, keep existing; if none exists, default today
+            entity.visitedDate = visitedDate ?? entity.visitedDate ?? Date()
+        } else {
+            entity.visitedDate = nil
+            // keep notes (better UX) — do NOT wipe them
+        }
+
+        try context.save()
+    }
+
+    func updateNotes(_ countryId: String, notes: String) throws {
+        let entity = try fetchOrCreateEntity(countryId: countryId)
+        entity.notes = notes
+        try context.save()
+    }
+
+    func visitedCount() throws -> Int {
+        let descriptor = FetchDescriptor<VisitEntity>(
+            predicate: #Predicate { $0.isVisited == true }
+        )
+        return try context.fetchCount(descriptor)
+    }
+
+    // MARK: - Private helpers
+
+    private func fetchEntity(countryId: String) throws -> VisitEntity? {
+        let descriptor = FetchDescriptor<VisitEntity>(
+            predicate: #Predicate { $0.countryId == countryId }
+        )
+        return try context.fetch(descriptor).first
+    }
+
+    private func fetchOrCreateEntity(countryId: String) throws -> VisitEntity {
+        if let existing = try fetchEntity(countryId: countryId) {
+            return existing
+        }
+        let created = VisitEntity(countryId: countryId)
+        context.insert(created)
+        return created
+    }
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/VisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/VisitRepository.swift
@@ -1,0 +1,15 @@
+//
+//  VisitRepository.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 2.03.2026.
+//
+
+import Foundation
+
+protocol VisitRepository {
+    func visit(for countryId: String) throws -> Visit
+    func setVisited(_ countryId: String, isVisited: Bool, visitedDate: Date?) throws
+    func updateNotes(_ countryId: String, notes: String) throws
+    func visitedCount() throws -> Int
+}


### PR DESCRIPTION
Closes #21

## Included
- VisitRepository protocol (domain-level abstraction)
- SwiftDataVisitRepository implementation
- Mapping between VisitEntity and Visit struct
- CRUD methods for visited state, date, notes, and count

## Notes
- UI and AppState still use in-memory storage
- Persistence integration will be handled in Issue #22

## How to test
- Build and run the app (no visible behavior change expected)
- Ensure project compiles successfully