### PR TITLE
Phase 2: AppState backed by SwiftData (persistent visit state)

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
@@ -10,13 +10,25 @@ import SwiftData
 
 @main
 struct WorldTrackerIOSApp: App {
-    @StateObject private var appState = AppState()
+    private let container: ModelContainer
+    @StateObject private var appState: AppState
+
+    init() {
+        do {
+            container = try ModelContainer(for: VisitEntity.self)
+            let context = ModelContext(container)
+            let repo = SwiftDataVisitRepository(context: context)
+            _appState = StateObject(wrappedValue: AppState(repository: repo))
+        } catch {
+            fatalError("Failed to create SwiftData container: \(error)")
+        }
+    }
 
     var body: some Scene {
         WindowGroup {
             RootTabView()
                 .environmentObject(appState)
         }
-        .modelContainer(for: [VisitEntity.self])
+        .modelContainer(container)
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/SwiftDataVisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/SwiftDataVisitRepository.swift
@@ -29,6 +29,19 @@ final class SwiftDataVisitRepository: VisitRepository {
         // default “not visited”
         return Visit(countryId: countryId, isVisited: false, visitedDate: nil, notes: "")
     }
+    
+    func allVisits() throws -> [Visit] {
+        let descriptor = FetchDescriptor<VisitEntity>()
+        let entities = try context.fetch(descriptor)
+        return entities.map {
+            Visit(
+                countryId: $0.countryId,
+                isVisited: $0.isVisited,
+                visitedDate: $0.visitedDate,
+                notes: $0.notes
+            )
+        }
+    }
 
     func setVisited(_ countryId: String, isVisited: Bool, visitedDate: Date?) throws {
         let entity = try fetchOrCreateEntity(countryId: countryId)

--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/VisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/VisitRepository.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol VisitRepository {
     func visit(for countryId: String) throws -> Visit
+    func allVisits() throws -> [Visit]
     func setVisited(_ countryId: String, isVisited: Bool, visitedDate: Date?) throws
     func updateNotes(_ countryId: String, notes: String) throws
     func visitedCount() throws -> Int

--- a/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
@@ -10,21 +10,35 @@ import Combine
 
 @MainActor
 final class AppState: ObservableObject {
-    /// Key = Country ISO code (Country.id)
-    @Published var visits: [String: Visit] = [:]
-    
+    @Published private(set) var visits: [String: Visit] = [:]
+
+    private let repository: VisitRepository
+
+    init(repository: VisitRepository) {
+        self.repository = repository
+        loadFromPersistence()
+    }
+
+    private func loadFromPersistence() {
+        do {
+            let stored = try repository.allVisits()
+            self.visits = Dictionary(uniqueKeysWithValues: stored.map { ($0.countryId, $0) })
+        } catch {
+            // In production you might log this; for now keep app usable
+            print("⚠️ Failed to load visits from SwiftData: \(error)")
+            self.visits = [:]
+        }
+    }
+
     func visit(for countryId: String) -> Visit {
         visits[countryId] ?? Visit(countryId: countryId, isVisited: false, visitedDate: nil, notes: "")
     }
-    
+
     func isVisited(_ countryId: String) -> Bool {
         visit(for: countryId).isVisited
     }
-    
-    func setVisited(_ countryId: String,
-                    isVisited: Bool,
-                    visitedDate: Date? = nil) {
 
+    func setVisited(_ countryId: String, isVisited: Bool, visitedDate: Date? = nil) {
         var v = visit(for: countryId)
         v.isVisited = isVisited
 
@@ -35,17 +49,34 @@ final class AppState: ObservableObject {
             // keep notes
         }
 
+        // Update UI immediately
         visits[countryId] = v
+
+        // Persist
+        do {
+            try repository.setVisited(countryId, isVisited: isVisited, visitedDate: v.visitedDate)
+        } catch {
+            print("⚠️ Failed to persist setVisited: \(error)")
+        }
     }
-    
+
     func updateNotes(_ countryId: String, notes: String) {
         var v = visit(for: countryId)
         v.notes = notes
+
+        // Update UI immediately
         visits[countryId] = v
+
+        // Persist
+        do {
+            try repository.updateNotes(countryId, notes: notes)
+        } catch {
+            print("⚠️ Failed to persist updateNotes: \(error)")
+        }
     }
-    
+
     // MARK: - Stats
-    
+
     var visitedCount: Int {
         visits.values.filter { $0.isVisited }.count
     }


### PR DESCRIPTION
Closes #22

## Overview
This PR refactors AppState to use the SwiftData-backed VisitRepository as its data source.

Previously, visit state was stored only in-memory using a dictionary.
After this change, visit data (visited state, visit date, notes) is persisted locally using SwiftData.

The UI layer remains unchanged and continues to interact only with AppState.

---

## Architectural Changes

### 1. Repository Integration
- AppState now depends on VisitRepository
- SwiftDataVisitRepository is injected during app initialization
- AppState loads all stored visits on initialization

### 2. Persistence Flow
- On state updates (setVisited / updateNotes), AppState:
  1. Updates the in-memory dictionary (for immediate UI updates)
  2. Persists changes via VisitRepository
- On app launch, AppState loads persisted visits from SwiftData

### 3. Separation of Concerns
- Views remain unaware of SwiftData
- AppState handles UI-facing state
- Repository layer handles persistence logic
- SwiftDataVisitRepository encapsulates all database operations

---

## Behavior Changes

✅ Visited state persists across app relaunch  
✅ Selected visit date persists  
✅ Notes persist  
✅ Stats visited count remains consistent after relaunch  

No UI regressions observed.

---

## How to Test

1. Run the app
2. Open a country
3. Toggle "Visited" ON
4. Change visit date
5. Add notes
6. Stop the app
7. Relaunch
8. Verify all data remains intact

---

## Phase 2 Progress

- SwiftData model container configured (#20)
- VisitRepository implemented (#21)
- AppState persistence integration completed (#22)

Persistence layer is now stable and ready for further feature development.