### PR TITLE
Phase 3: Map pins for visited countries

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
@@ -11,6 +11,7 @@ import Combine
 @MainActor
 final class AppState: ObservableObject {
     @Published private(set) var visits: [String: Visit] = [:]
+    @Published private(set) var visitedCountryIDs: Set<String> = []
 
     private let repository: VisitRepository
 
@@ -23,10 +24,11 @@ final class AppState: ObservableObject {
         do {
             let stored = try repository.allVisits()
             self.visits = Dictionary(uniqueKeysWithValues: stored.map { ($0.countryId, $0) })
+            self.visitedCountryIDs = Set(stored.filter { $0.isVisited }.map { $0.countryId })
         } catch {
-            // In production you might log this; for now keep app usable
             print("⚠️ Failed to load visits from SwiftData: \(error)")
             self.visits = [:]
+            self.visitedCountryIDs = []
         }
     }
 
@@ -46,11 +48,15 @@ final class AppState: ObservableObject {
             v.visitedDate = visitedDate ?? v.visitedDate ?? Date()
         } else {
             v.visitedDate = nil
-            // keep notes
         }
 
         // Update UI immediately
         visits[countryId] = v
+        if isVisited {
+            visitedCountryIDs.insert(countryId)
+        } else {
+            visitedCountryIDs.remove(countryId)
+        }
 
         // Persist
         do {
@@ -63,19 +69,14 @@ final class AppState: ObservableObject {
     func updateNotes(_ countryId: String, notes: String) {
         var v = visit(for: countryId)
         v.notes = notes
-
-        // Update UI immediately
         visits[countryId] = v
 
-        // Persist
         do {
             try repository.updateNotes(countryId, notes: notes)
         } catch {
             print("⚠️ Failed to persist updateNotes: \(error)")
         }
     }
-
-    // MARK: - Stats
 
     var visitedCount: Int {
         visits.values.filter { $0.isVisited }.count

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -9,20 +9,37 @@ import SwiftUI
 import MapKit
 
 struct MapScreen: View {
+    @EnvironmentObject private var appState: AppState
+    private let countries = MockCountryService().loadCountries()
+
     @State private var cameraPosition: MapCameraPosition = .region(
         MKCoordinateRegion(
-            center: CLLocationCoordinate2D(latitude: 20, longitude: 0), // roughly world center
+            center: CLLocationCoordinate2D(latitude: 20, longitude: 0),
             span: MKCoordinateSpan(latitudeDelta: 120, longitudeDelta: 120)
         )
     )
 
+    var visitedCountries: [Country] {
+        countries.filter { appState.visitedCountryIDs.contains($0.id) }
+    }
+
     var body: some View {
         NavigationStack {
-            Map(position: $cameraPosition)
-                .mapStyle(.standard(elevation: .realistic))
-                .ignoresSafeArea(edges: .bottom)
-                .navigationTitle("Map")
-                .navigationBarTitleDisplayMode(.inline)
+            Map(position: $cameraPosition) {
+                ForEach(visitedCountries) { country in
+                    Annotation(country.name, coordinate: country.centroid.clLocation) {
+                        VStack(spacing: 2) {
+                            Text(country.flagEmoji)
+                            Image(systemName: "mappin.circle.fill")
+                                .font(.title3)
+                        }
+                    }
+                }
+            }
+            .mapStyle(.standard(elevation: .realistic))
+            .ignoresSafeArea(edges: .bottom)
+            .navigationTitle("Map")
+            .navigationBarTitleDisplayMode(.inline)
         }
     }
 }


### PR DESCRIPTION
Closes #32

Adds map annotations for visited countries using MapKit.

Features:
- Pins appear for visited countries only
- Coordinates derived from country centroids
- Data sourced from SwiftData via AppState
- Pins persist across app launches

Testing:
1. Mark a country as visited
2. Open Map tab
3. Verify pin appears
4. Relaunch app to confirm persistence