### PR TITLE
Phase 3: Map selection opens CountryDetailScreen

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Models/Country.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Models/Country.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Country: Identifiable, Codable {
+struct Country: Identifiable, Codable, Hashable {
     let id: String
     let name: String
     let continent: Continent

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -19,8 +19,11 @@ struct MapScreen: View {
         )
     )
 
-    var visitedCountries: [Country] {
-        countries.filter { appState.visitedCountryIDs.contains($0.id) }
+    @State private var selectedCountry: Country? = nil
+
+    private var visitedCountries: [Country] {
+        countries.filter { appState.isVisited($0.id) }
+        // or: countries.filter { appState.visitedCountryIDs.contains($0.id) }
     }
 
     var body: some View {
@@ -29,10 +32,10 @@ struct MapScreen: View {
                 ForEach(visitedCountries) { country in
                     Annotation(country.name, coordinate: country.centroid.clLocation) {
                         VStack(spacing: 2) {
-                            Text(country.flagEmoji)
-                            Image(systemName: "mappin.circle.fill")
-                                .font(.title3)
+                            Text(country.flagEmoji).font(.title3)
+                            Image(systemName: "mappin.circle.fill").font(.title3)
                         }
+                        .onTapGesture { selectedCountry = country }
                     }
                 }
             }
@@ -40,6 +43,9 @@ struct MapScreen: View {
             .ignoresSafeArea(edges: .bottom)
             .navigationTitle("Map")
             .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(item: $selectedCountry) { country in
+                CountryDetailScreen(country: country)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #33 
Implements map interaction allowing users to open the CountryDetailScreen directly from the map.

Features:
- Display visited countries as pins using MapKit annotations
- Tap gesture on annotation selects a country
- NavigationStack pushes CountryDetailScreen via navigationDestination
- Uses Country as Identifiable + Hashable for navigation

Architecture:
- MapScreen reads visited countries from AppState
- Navigation handled using SwiftUI navigationDestination(item:)
- No additional state duplication required

Result:
Users can tap any visited country pin on the map and navigate directly to its detail screen.