### PR TITLE
Phase 3: Map QA + edge case validation

### DIFF
--- a/docs/PHASE3_QA.md
+++ b/docs/PHASE3_QA.md
@@ -1,0 +1,142 @@
+# Phase 3 QA – Map Feature Validation
+
+## Build Information
+- Platform: iOS
+- Deployment Target: iOS 17+
+- Tested On: Physical iPhone Device
+- Architecture: SwiftUI + SwiftData + MapKit
+- Branch: Phase 3 (Map feature)
+
+---
+
+# Scope of Phase 3
+
+Phase 3 introduces the first functional version of the **Map tab** using MapKit.
+
+Features implemented:
+- Display visited countries on a world map
+- Render visited countries as MapKit annotations (pins)
+- Tap annotation to open `CountryDetailScreen`
+- Persist visited countries using SwiftData
+- Navigation handled using `NavigationStack`
+
+Future improvements (planned Phase 4):
+- Country polygon highlighting
+- Map performance improvements
+- Additional UX enhancements
+
+---
+
+# Test Scenarios
+
+## 1. Empty State – No Visited Countries
+
+### Steps
+1. Launch the app with a fresh install.
+2. Navigate to the **Map** tab.
+
+### Expected Result
+- Map loads successfully.
+- No annotations are displayed.
+- Application remains stable.
+
+### Result
+✅ Passed
+
+---
+
+## 2. Single Visited Country
+
+### Steps
+1. Navigate to **Countries**.
+2. Open a country.
+3. Toggle **Visited** ON.
+4. Select a visit date.
+5. Navigate to **Map** tab.
+
+### Expected Result
+- One annotation appears for the visited country.
+- Annotation displays correct location.
+
+### Result
+✅ Passed
+
+---
+
+## 3. Map Annotation Interaction
+
+### Steps
+1. Tap a visited country pin on the map.
+
+### Expected Result
+- App navigates to `CountryDetailScreen`.
+- Correct country details are displayed.
+- Back navigation returns to the map.
+
+### Result
+✅ Passed
+
+---
+
+## 4. Multiple Visited Countries
+
+### Steps
+1. Mark several countries as visited.
+2. Navigate to **Map** tab.
+
+### Expected Result
+- Pins appear for all visited countries.
+- Map interaction (pan / zoom) remains responsive.
+
+### Result
+✅ Passed
+
+---
+
+## 5. Persistence Test (SwiftData)
+
+### Steps
+1. Mark multiple countries as visited.
+2. Close the application.
+3. Relaunch the application.
+4. Navigate to **Map** tab.
+
+### Expected Result
+- Previously visited countries still appear as pins.
+
+### Result
+✅ Passed
+
+---
+
+# Observations
+
+- Map annotations correctly reflect visited state.
+- Navigation from Map → CountryDetailScreen works reliably.
+- SwiftData persistence successfully restores visited countries after app restart.
+- No crashes or UI inconsistencies observed during testing.
+
+---
+
+# Known Limitations
+
+Current Phase 3 implementation intentionally keeps the map simple.
+
+Not included yet:
+- Country polygon highlighting
+- Annotation clustering
+- Map performance optimization for large datasets
+
+These improvements are planned for **Phase 4**.
+
+---
+
+# Conclusion
+
+The Phase 3 Map feature functions as expected and integrates correctly with:
+
+- SwiftData persistence layer
+- `AppState` state management
+- `CountryDetailScreen` navigation flow
+
+All tested scenarios passed successfully and the feature is ready to proceed to the next development phase.


### PR DESCRIPTION
Closes #34

## Summary
This PR adds the QA validation report for the Phase 3 Map feature.

Phase 3 introduced the first functional implementation of the Map tab using MapKit.  
Visited countries are displayed as annotations and tapping a pin navigates to the corresponding `CountryDetailScreen`.

This PR documents the testing process and confirms that the feature behaves correctly across key scenarios.

## Tested Scenarios

- Empty state (no visited countries)
- Single visited country
- Multiple visited countries
- Map annotation interaction (tap → CountryDetailScreen)
- Data persistence after app restart

## Results

All test scenarios passed successfully.

Verified behaviors:
- Map loads correctly when no countries are visited
- Pins appear for visited countries
- Tapping a pin navigates to the correct country detail
- Navigation back to the map works reliably
- SwiftData persistence restores visited countries after app restart

## Testing Environment

- Platform: iOS
- Deployment Target: iOS 17+
- Device: Physical iPhone
- Architecture: SwiftUI + SwiftData + MapKit

## Notes

Current map implementation intentionally keeps the visualization simple:
- Pins represent visited countries
- Country polygon highlighting and map performance improvements are planned for Phase 4

See `PHASE3_QA.md` for the complete validation report.