### PR TITLE
Phase 4: Stats polish + tappable recent visits

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
@@ -101,32 +101,37 @@ struct StatsScreen: View {
                         }
                     }
                 }
-
                 Section("Recent visits") {
                     if recentVisits.isEmpty {
                         Text("No visits yet.")
                             .foregroundStyle(.secondary)
                     } else {
                         ForEach(recentVisits.prefix(10), id: \.country.id) { item in
-                            HStack(spacing: 12) {
-                                Text(item.country.flagEmoji)
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(item.country.name)
-                                    Text(item.country.continent.displayName)
+                            NavigationLink {
+                                CountryDetailScreen(country: item.country)
+                            } label: {
+                                HStack(spacing: 12) {
+                                    Text(item.country.flagEmoji)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(item.country.name)
+                                        Text(item.country.continent.displayName)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Spacer()
+                                    Text(formattedDate(item.date))
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                 }
-                                Spacer()
-                                Text(formattedDate(item.date))
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                                .padding(.vertical, 2)
+                                .contentShape(Rectangle())
                             }
-                            .padding(.vertical, 2)
                         }
                     }
                 }
             }
             .navigationTitle("Stats")
+            .listStyle(.insetGrouped)
         }
     }
 


### PR DESCRIPTION
Closes #43

This PR improves the Stats tab by making recent visits interactive.

## Included
- Recent visits now use NavigationLink
- Tapping a recent visit opens CountryDetailScreen
- Existing stats features remain unchanged:
  - overview count
  - visited by continent
  - recent visits sorted by date

## How to test
1. Mark multiple countries as visited with different dates
2. Open Stats tab
3. Verify recent visits are sorted correctly
4. Tap a recent visit
5. Confirm CountryDetailScreen opens for the selected country