### PR TITLE
Phase 4: Firebase Authentication (email/password + session state UI)

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
@@ -11,6 +11,8 @@ import FirebaseCore
 
 @main
 struct WorldTrackerIOSApp: App {
+    @StateObject private var authService = AuthService()
+
     private let container: ModelContainer
     @StateObject private var appState: AppState
 
@@ -31,6 +33,7 @@ struct WorldTrackerIOSApp: App {
         WindowGroup {
             RootTabView()
                 .environmentObject(appState)
+                .environmentObject(authService)
         }
         .modelContainer(container)
     }

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
@@ -1,0 +1,51 @@
+//
+//  AuthService.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 9.03.2026.
+//
+
+import Foundation
+import Combine
+import FirebaseAuth
+
+@MainActor
+final class AuthService: ObservableObject {
+    @Published private(set) var user: User?
+
+    var userEmail: String {
+        user?.email ?? "Unknown user"
+    }
+    
+    private var authStateHandle: AuthStateDidChangeListenerHandle?
+
+    init() {
+        user = Auth.auth().currentUser
+
+        authStateHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            self?.user = user
+        }
+    }
+
+    deinit {
+        if let authStateHandle {
+            Auth.auth().removeStateDidChangeListener(authStateHandle)
+        }
+    }
+
+    var isSignedIn: Bool {
+        user != nil
+    }
+
+    func signUp(email: String, password: String) async throws {
+        _ = try await Auth.auth().createUser(withEmail: email, password: password)
+    }
+
+    func signIn(email: String, password: String) async throws {
+        _ = try await Auth.auth().signIn(withEmail: email, password: password)
+    }
+
+    func signOut() throws {
+        try Auth.auth().signOut()
+    }
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
@@ -1,0 +1,41 @@
+//
+//  AccountScreen.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 9.03.2026.
+//
+
+import SwiftUI
+
+struct AccountScreen: View {
+    @EnvironmentObject private var authService: AuthService
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Session") {
+                    Text(authService.userEmail)
+                }
+
+                Section {
+                    Button("Sign out", role: .destructive) {
+                        do {
+                            try authService.signOut()
+                        } catch {
+                            errorMessage = error.localizedDescription
+                        }
+                    }
+                }
+
+                if let errorMessage {
+                    Section("Error") {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Account")
+        }
+    }
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
@@ -1,0 +1,68 @@
+//
+//  AuthScreen.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 9.03.2026.
+//
+
+import SwiftUI
+
+struct AuthScreen: View {
+    @EnvironmentObject private var authService: AuthService
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var isCreatingAccount = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Account") {
+                    TextField("Email", text: $email)
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.emailAddress)
+                        .autocorrectionDisabled()
+
+                    SecureField("Password", text: $password)
+                }
+
+                Section {
+                    Button(isCreatingAccount ? "Create account" : "Sign in") {
+                        Task {
+                            await submit()
+                        }
+                    }
+                    .disabled(email.isEmpty || password.isEmpty)
+
+                    Button(isCreatingAccount ? "Already have an account? Sign in"
+                                             : "Need an account? Sign up") {
+                        isCreatingAccount.toggle()
+                    }
+                }
+
+                if let errorMessage {
+                    Section("Error") {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Account")
+        }
+    }
+
+    private func submit() async {
+        errorMessage = nil
+
+        do {
+            if isCreatingAccount {
+                try await authService.signUp(email: email, password: password)
+            } else {
+                try await authService.signIn(email: email, password: password)
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabVİew.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabVİew.swift
@@ -5,20 +5,38 @@
 //  Created by seren on 25.02.2026.
 //
 
-import Foundation
 import SwiftUI
 
 struct RootTabView: View {
+    @EnvironmentObject private var authService: AuthService
+
     var body: some View {
         TabView {
             MapScreen()
-                .tabItem { Label("Map", systemImage: "map") }
+                .tabItem {
+                    Label("Map", systemImage: "map")
+                }
             
             CountriesScreen()
-                .tabItem { Label("Countries", systemImage: "list.bullet") }
-            
+                .tabItem {
+                    Label("Countries", systemImage: "list.bullet")
+                }
+
             StatsScreen()
-                .tabItem { Label("Stats", systemImage: "chart.bar") }
+                .tabItem {
+                    Label("Stats", systemImage: "chart.bar")
+                }
+
+            Group {
+                if authService.isSignedIn {
+                    AccountScreen()
+                } else {
+                    AuthScreen()
+                }
+            }
+            .tabItem {
+                Label("Account", systemImage: "person.circle")
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #45

## Summary
This PR introduces Firebase Authentication to the app using email/password login.

It adds a simple authentication flow that allows users to:
- create an account
- sign in
- sign out
- persist session state between app launches

Authentication state is exposed through a dedicated `AuthService`, which is injected into the app environment and observed by the UI.

## Architecture
A new `AuthService` was implemented to manage Firebase authentication state and operations.

Responsibilities:
- observe Firebase session state (`AuthStateDidChangeListener`)
- expose `user` and `isSignedIn`
- provide async APIs for:
  - `signUp`
  - `signIn`
  - `signOut`

The service is injected via `environmentObject` in `WorldTrackerIOSApp`.

## UI
Two new screens were added:

### AuthScreen
Handles:
- email/password sign up
- email/password sign in
- basic error handling

### AccountScreen
Displays:
- current signed-in user email
- sign out button
- error feedback

The `RootTabView` now conditionally displays:
- `AuthScreen` when the user is signed out
- `AccountScreen` when the user is signed in

## Firebase Setup
Firebase Authentication was enabled with:
- Email/Password provider

The Firebase SDK was already initialized earlier in Phase 4 with:
Closes #45

## Summary
This PR introduces Firebase Authentication to the app using email/password login.

It adds a simple authentication flow that allows users to:
- create an account
- sign in
- sign out
- persist session state between app launches

Authentication state is exposed through a dedicated `AuthService`, which is injected into the app environment and observed by the UI.

## Architecture
A new `AuthService` was implemented to manage Firebase authentication state and operations.

Responsibilities:
- observe Firebase session state (`AuthStateDidChangeListener`)
- expose `user` and `isSignedIn`
- provide async APIs for:
  - `signUp`
  - `signIn`
  - `signOut`

The service is injected via `environmentObject` in `WorldTrackerIOSApp`.

## UI
Two new screens were added:

### AuthScreen
Handles:
- email/password sign up
- email/password sign in
- basic error handling

### AccountScreen
Displays:
- current signed-in user email
- sign out button
- error feedback

The `RootTabView` now conditionally displays:
- `AuthScreen` when the user is signed out
- `AccountScreen` when the user is signed in

## Firebase Setup
Firebase Authentication was enabled with:
- Email/Password provider

The Firebase SDK was already initialized earlier in Phase 4 with:
FirebaseApp.configure()

## Testing
Tested on iOS Simulator.

Checklist:
- [x] create account with email/password
- [x] sign out
- [x] sign in again
- [x] session persists after app restart
- [x] new user appears in Firebase Console

## Notes
This PR introduces authentication only.

Cloud synchronization of visits will be implemented in the next steps using Firestore.