### PR TITLE
Phase 4: FirestoreVisitRepository (async/await CRUD + typed errors)

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
@@ -1,0 +1,214 @@
+//
+//  FirestoreVisitRepository.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 10.03.2026.
+//
+
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+import FirebaseCore
+
+final class FirestoreVisitRepository {
+    private let db = Firestore.firestore()
+
+    // MARK: - Public API
+
+    func visit(for countryId: String) async throws -> Visit {
+        let doc = try await getVisitDocument(countryId: countryId)
+
+        guard let data = doc.data() else {
+            throw FirestoreVisitRepositoryError.documentNotFound
+        }
+
+        return try mapVisit(countryId: countryId, data: data)
+    }
+
+    func allVisits() async throws -> [Visit] {
+        let userID = try requireUserID()
+
+        let snapshot = try await getDocuments(
+            from: db.collection("users")
+                .document(userID)
+                .collection("visits")
+        )
+
+        return try snapshot.documents.map { document in
+            try mapVisit(countryId: document.documentID, data: document.data())
+        }
+    }
+
+    func setVisited(_ countryId: String, isVisited: Bool, visitedDate: Date?, notes: String) async throws {
+        let userID = try requireUserID()
+
+        let data: [String: Any] = [
+            "isVisited": isVisited,
+            "visitedDate": visitedDate as Any,
+            "notes": notes,
+            "updatedAt": Timestamp(date: Date())
+        ]
+
+        try await setData(
+            data,
+            for: db.collection("users")
+                .document(userID)
+                .collection("visits")
+                .document(countryId)
+        )
+    }
+
+    func updateNotes(_ countryId: String, notes: String) async throws {
+        let userID = try requireUserID()
+
+        let ref = db.collection("users")
+            .document(userID)
+            .collection("visits")
+            .document(countryId)
+
+        let data: [String: Any] = [
+            "notes": notes,
+            "updatedAt": Timestamp(date: Date())
+        ]
+
+        try await updateData(data, for: ref)
+    }
+
+    func deleteVisit(_ countryId: String) async throws {
+        let userID = try requireUserID()
+
+        try await deleteDocument(
+            db.collection("users")
+                .document(userID)
+                .collection("visits")
+                .document(countryId)
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func requireUserID() throws -> String {
+        guard let uid = Auth.auth().currentUser?.uid else {
+            throw FirestoreVisitRepositoryError.notAuthenticated
+        }
+        return uid
+    }
+
+    private func getVisitDocument(countryId: String) async throws -> DocumentSnapshot {
+        let userID = try requireUserID()
+
+        return try await getDocument(
+            from: db.collection("users")
+                .document(userID)
+                .collection("visits")
+                .document(countryId)
+        )
+    }
+
+    private func mapVisit(countryId: String, data: [String: Any]) throws -> Visit {
+        guard let isVisited = data["isVisited"] as? Bool else {
+            throw FirestoreVisitRepositoryError.invalidData
+        }
+
+        let notes = data["notes"] as? String ?? ""
+
+        let visitedDate: Date?
+        if let timestamp = data["visitedDate"] as? Timestamp {
+            visitedDate = timestamp.dateValue()
+        } else {
+            visitedDate = nil
+        }
+
+        return Visit(
+            countryId: countryId,
+            isVisited: isVisited,
+            visitedDate: visitedDate,
+            notes: notes
+        )
+    }
+
+    // MARK: - Async wrappers
+
+    private func getDocument(from ref: DocumentReference) async throws -> DocumentSnapshot {
+        try await withCheckedThrowingContinuation { continuation in
+            ref.getDocument { snapshot, error in
+                if let error {
+                    continuation.resume(throwing: self.mapError(error))
+                    return
+                }
+
+                guard let snapshot else {
+                    continuation.resume(throwing: FirestoreVisitRepositoryError.documentNotFound)
+                    return
+                }
+
+                continuation.resume(returning: snapshot)
+            }
+        }
+    }
+
+    private func getDocuments(from ref: CollectionReference) async throws -> QuerySnapshot {
+        try await withCheckedThrowingContinuation { continuation in
+            ref.getDocuments { snapshot, error in
+                if let error {
+                    continuation.resume(throwing: self.mapError(error))
+                    return
+                }
+
+                guard let snapshot else {
+                    continuation.resume(throwing: FirestoreVisitRepositoryError.invalidData)
+                    return
+                }
+
+                continuation.resume(returning: snapshot)
+            }
+        }
+    }
+
+    private func setData(_ data: [String: Any], for ref: DocumentReference) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            ref.setData(data) { error in
+                if let error {
+                    continuation.resume(throwing: self.mapError(error))
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    private func updateData(_ data: [String: Any], for ref: DocumentReference) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            ref.updateData(data) { error in
+                if let error {
+                    continuation.resume(throwing: self.mapError(error))
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    private func deleteDocument(_ ref: DocumentReference) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            ref.delete { error in
+                if let error {
+                    continuation.resume(throwing: self.mapError(error))
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    private func mapError(_ error: Error) -> FirestoreVisitRepositoryError {
+        let nsError = error as NSError
+
+        // 7 is permission denied in gRPC / Firestore permission failures
+        if nsError.code == 7 {
+            return .permissionDenied
+        }
+
+        return .unknown(error)
+    }
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepositoryError.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepositoryError.swift
@@ -1,0 +1,31 @@
+//
+//  FirestoreVisitRepositoryError.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 10.03.2026.
+//
+
+import Foundation
+
+enum FirestoreVisitRepositoryError: LocalizedError {
+    case notAuthenticated
+    case documentNotFound
+    case invalidData
+    case permissionDenied
+    case unknown(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "User is not authenticated."
+        case .documentNotFound:
+            return "Document not found."
+        case .invalidData:
+            return "Firestore document contains invalid data."
+        case .permissionDenied:
+            return "Permission denied."
+        case .unknown(let error):
+            return error.localizedDescription
+        }
+    }
+}


### PR DESCRIPTION
Closes #47

## Summary
This PR adds the first Firestore data access layer for cloud visit storage.

## Included
- FirestoreVisitRepository
- async/await wrappers for Firestore document operations
- typed repository errors
- mapping between Firestore documents and Visit model

## Testing
Verified signed-in repository behavior:
- allVisits() executes successfully
- setVisited() writes Firestore documents correctly
- visit(for:) fetches and maps Firestore data into Visit

## Notes
- This PR does not yet integrate Firestore into AppState
- SwiftData remains the active source used by the UI
- Sync and merge logic will be added in later issues