### PR TITLE
Phase 4: AppState integration with cloud sync

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
@@ -22,8 +22,20 @@ struct WorldTrackerIOSApp: App {
         do {
             container = try ModelContainer(for: VisitEntity.self)
             let context = ModelContext(container)
-            let repo = SwiftDataVisitRepository(context: context)
-            _appState = StateObject(wrappedValue: AppState(repository: repo))
+            
+            let localRepo = SwiftDataVisitRepository(context: context)
+            let cloudRepo = FirestoreVisitRepository()
+            let syncService = SyncService(
+                localRepository: localRepo,
+                cloudRepository: cloudRepo
+            )
+            
+            _appState = StateObject(
+                wrappedValue: AppState(
+                    repository: localRepo,
+                    syncService: syncService
+                )
+            )
         } catch {
             fatalError("Failed to create SwiftData container: \(error)")
         }

--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/SwiftDataVisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/SwiftDataVisitRepository.swift
@@ -44,6 +44,17 @@ final class SwiftDataVisitRepository: VisitRepository {
             )
         }
     }
+    
+    func deleteAllVisits() throws {
+        let descriptor = FetchDescriptor<VisitEntity>()
+        let entities = try context.fetch(descriptor)
+
+        for entity in entities {
+            context.delete(entity)
+        }
+
+        try context.save()
+    }
 
     func setVisited(_ countryId: String, isVisited: Bool, visitedDate: Date?) throws {
         let entity = try fetchOrCreateEntity(countryId: countryId)
@@ -71,12 +82,12 @@ final class SwiftDataVisitRepository: VisitRepository {
     }
     
     func upsert(_ visit: Visit) throws {
-            let entity = try fetchOrCreateEntity(countryId: visit.countryId)
-            entity.isVisited = visit.isVisited
-            entity.visitedDate = visit.visitedDate
-            entity.notes = visit.notes
-            entity.updatedAt = visit.updatedAt
-            try context.save()
+        let entity = try fetchOrCreateEntity(countryId: visit.countryId)
+        entity.isVisited = visit.isVisited
+        entity.visitedDate = visit.visitedDate
+        entity.notes = visit.notes
+        entity.updatedAt = visit.updatedAt
+        try context.save()
     }
 
     func visitedCount() throws -> Int {

--- a/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
@@ -14,9 +14,11 @@ final class AppState: ObservableObject {
     @Published private(set) var visitedCountryIDs: Set<String> = []
 
     private let repository: VisitRepository
+    private let syncService: SyncService?
 
-    init(repository: VisitRepository) {
+    init(repository: VisitRepository, syncService: SyncService? = nil) {
         self.repository = repository
+        self.syncService = syncService
         loadFromPersistence()
     }
 
@@ -32,6 +34,21 @@ final class AppState: ObservableObject {
         }
     }
 
+    func refreshFromPersistence() {
+        loadFromPersistence()
+    }
+    
+    func syncWithCloud() async {
+        guard let syncService else { return }
+
+        do {
+            try await syncService.syncVisits()
+            loadFromPersistence()
+        } catch {
+            print("⚠️ Sync failed: \(error)")
+        }
+    }
+    
     func visit(for countryId: String) -> Visit {
         visits[countryId] ?? Visit(countryId: countryId, isVisited: false, visitedDate: nil, notes: "", updatedAt: Date())
     }
@@ -49,6 +66,7 @@ final class AppState: ObservableObject {
         } else {
             v.visitedDate = nil
         }
+        v.updatedAt = Date()
 
         // Update UI immediately
         visits[countryId] = v
@@ -61,6 +79,9 @@ final class AppState: ObservableObject {
         // Persist
         do {
             try repository.setVisited(countryId, isVisited: isVisited, visitedDate: v.visitedDate)
+            Task {
+                await syncWithCloud()
+            }
         } catch {
             print("⚠️ Failed to persist setVisited: \(error)")
         }
@@ -69,10 +90,14 @@ final class AppState: ObservableObject {
     func updateNotes(_ countryId: String, notes: String) {
         var v = visit(for: countryId)
         v.notes = notes
+        v.updatedAt = Date()
         visits[countryId] = v
 
         do {
             try repository.updateNotes(countryId, notes: notes)
+            Task {
+                await syncWithCloud()
+            }
         } catch {
             print("⚠️ Failed to persist updateNotes: \(error)")
         }
@@ -80,5 +105,21 @@ final class AppState: ObservableObject {
 
     var visitedCount: Int {
         visits.values.filter { $0.isVisited }.count
+    }
+    
+    func clearLocalState() {
+        visits = [:]
+        visitedCountryIDs = []
+    }
+    
+    func clearLocalDataAfterSignOut() {
+        do {
+            if let localRepository = repository as? SwiftDataVisitRepository {
+                try localRepository.deleteAllVisits()
+            }
+            clearLocalState()
+        } catch {
+            print("⚠️ Failed to clear local data after sign out: \(error)")
+        }
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AccountScreen: View {
     @EnvironmentObject private var authService: AuthService
     @State private var errorMessage: String?
+    @EnvironmentObject private var appState: AppState
 
     var body: some View {
         NavigationStack {
@@ -22,6 +23,7 @@ struct AccountScreen: View {
                     Button("Sign out", role: .destructive) {
                         do {
                             try authService.signOut()
+                            appState.clearLocalDataAfterSignOut()
                         } catch {
                             errorMessage = error.localizedDescription
                         }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AuthScreen: View {
     @EnvironmentObject private var authService: AuthService
+    @EnvironmentObject private var appState: AppState
 
     @State private var email = ""
     @State private var password = ""
@@ -61,6 +62,8 @@ struct AuthScreen: View {
             } else {
                 try await authService.signIn(email: email, password: password)
             }
+
+            await appState.syncWithCloud()
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
@@ -1,5 +1,5 @@
 //
-//  RootTabVİew.swift
+//  RootTabView.swift
 //  WorldTrackerIOS
 //
 //  Created by seren on 25.02.2026.
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct RootTabView: View {
     @EnvironmentObject private var authService: AuthService
+    @EnvironmentObject private var appState: AppState
 
     var body: some View {
         TabView {
@@ -36,6 +37,11 @@ struct RootTabView: View {
             }
             .tabItem {
                 Label("Account", systemImage: "person.circle")
+            }
+        }
+        .task {
+            if authService.isSignedIn {
+                await appState.syncWithCloud()
             }
         }
     }


### PR DESCRIPTION
Closes #49

## Summary
This PR integrates cloud synchronization into `AppState` so that Firestore sync updates the UI automatically.

## Included
- `AppState` now accepts an optional `SyncService`
- added `syncWithCloud()` to `AppState`
- local writes now trigger sync when available
- `AppState` reloads from SwiftData after sync
- sign-in triggers cloud sync
- signed-out users now clear synced local state from SwiftData and memory

## Result
Cloud-only changes now appear in the UI without requiring an app restart.

## Testing
Verified the following scenarios:
- sign-in triggers sync and cloud visits appear immediately
- local writes continue to persist and sync correctly
- sign-out clears synced local data and resets UI state