### PR TITLE
Implement map preview bubbles with persistent map annotations

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Services/CountryBoundaryService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/CountryBoundaryService.swift
@@ -61,8 +61,6 @@ final class CountryBoundaryService {
                 guard !overlays.isEmpty else { continue }
                 result[countryCode, default: []].append(contentsOf: overlays)
             }
-
-            print("🗺️ Loaded country overlays: \(result.keys.count) countries")
             
             return result
         } catch {

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryMapPreviewBubble.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryMapPreviewBubble.swift
@@ -1,0 +1,255 @@
+//
+//  CountryMapPreviewBubble.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 26.03.2026.
+//
+
+import SwiftUI
+import MapKit
+
+// MARK: - Map Annotation Bubble (Always Visible)
+
+/// Compact bubble that appears as an annotation on the map for visited countries
+struct CountryMapAnnotationBubble: View {
+    let country: Country
+    let visit: Visit
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            // Main bubble content
+            HStack(spacing: 8) {
+                // Preview indicator
+                if let firstPhoto = visit.photos.first,
+                   let uiImage = UIImage(data: firstPhoto.imageData) {
+                    // Photo thumbnail
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 40, height: 40)
+                        .clipShape(Circle())
+                        .overlay(
+                            Circle()
+                                .stroke(Color.white, lineWidth: 2)
+                        )
+                } else if !visit.notes.isEmpty {
+                    // Note indicator
+                    ZStack {
+                        Circle()
+                            .fill(Color.blue.gradient)
+                            .frame(width: 40, height: 40)
+                        
+                        Image(systemName: "note.text")
+                            .font(.system(size: 18))
+                            .foregroundStyle(.white)
+                    }
+                    .overlay(
+                        Circle()
+                            .stroke(Color.white, lineWidth: 2)
+                    )
+                } else {
+                    // Just visited indicator
+                    ZStack {
+                        Circle()
+                            .fill(Color.green.gradient)
+                            .frame(width: 40, height: 40)
+                        
+                        Text(country.flagEmoji)
+                            .font(.system(size: 20))
+                    }
+                    .overlay(
+                        Circle()
+                            .stroke(Color.white, lineWidth: 2)
+                    )
+                }
+                
+                // Country name label (optional - can be hidden at far zoom)
+                Text(country.name)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.ultraThinMaterial)
+                    .clipShape(Capsule())
+            }
+            .padding(6)
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 24))
+            .shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 2)
+            
+            // Pointer/tail
+            Triangle()
+                .fill(.ultraThinMaterial)
+                .frame(width: 12, height: 6)
+                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+        }
+    }
+}
+
+/// Triangle shape for bubble pointer
+struct Triangle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+// MARK: - Full Preview Bubble (Modal/Sheet)
+
+struct CountryMapPreviewBubble: View {
+    let country: Country
+    let visit: Visit
+    let onDismiss: () -> Void
+    let onViewDetails: () -> Void
+    
+    @State private var appeared = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header with country info
+            HStack(spacing: 12) {
+                Text(country.flagEmoji)
+                    .font(.system(size: 32))
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(country.name)
+                        .font(.headline)
+                        .lineLimit(1)
+                    
+                    if let visitDate = visit.visitedDate {
+                        Text(visitDate, style: .date)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                
+                Spacer()
+                
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .symbolRenderingMode(.hierarchical)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(12)
+            
+            // Content preview
+            if hasContent {
+                Divider()
+                
+                VStack(alignment: .leading, spacing: 12) {
+                    // Photo preview (if available)
+                    if let firstPhoto = visit.photos.first,
+                       let uiImage = UIImage(data: firstPhoto.imageData) {
+                        Image(uiImage: uiImage)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 120)
+                            .clipped()
+                            .cornerRadius(6)
+                        
+                        if visit.photos.count > 1 {
+                            HStack(spacing: 4) {
+                                Image(systemName: "photo.stack")
+                                    .font(.caption2)
+                                Text("\(visit.photos.count) photos")
+                                    .font(.caption2)
+                            }
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                    
+                    // Notes preview (if available)
+                    if !visit.notes.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Notes")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            
+                            Text(visit.notes)
+                                .font(.subheadline)
+                                .foregroundStyle(.primary)
+                                .lineLimit(3)
+                                .multilineTextAlignment(.leading)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 12)
+            }
+            
+            // View Details button
+            Divider()
+            
+            Button {
+                onViewDetails()
+            } label: {
+                HStack {
+                    Text("View Details")
+                        .font(.subheadline.weight(.medium))
+                    
+                    Spacer()
+                    
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: 340)
+        .background(.ultraThinMaterial)
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 4)
+        .scaleEffect(appeared ? 1.0 : 0.8)
+        .opacity(appeared ? 1.0 : 0.0)
+        .onAppear {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                appeared = true
+            }
+        }
+    }
+    
+    private var hasContent: Bool {
+        !visit.photos.isEmpty || !visit.notes.isEmpty
+    }
+    
+    private func dismiss() {
+        withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
+            appeared = false
+        }
+        
+        // Delay actual dismissal to allow animation to complete
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            onDismiss()
+        }
+    }
+}
+
+// MARK: - Preview Container
+
+/// Wrapper to hold country and visit data for preview
+struct CountryPreviewData: Identifiable {
+    let id: String
+    let country: Country
+    let visit: Visit
+    
+    init(country: Country, visit: Visit) {
+        self.id = country.id
+        self.country = country
+        self.visit = visit
+    }
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/CountryDataService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/CountryDataService.swift
@@ -376,6 +376,43 @@ final class CountryDataService {
     }
     
     private func calculateCentroid(from geometries: [MKGeoJSONObject]) -> Coordinate {
+        // Find the largest polygon to use for centroid calculation
+        // This avoids offshore territories skewing the result
+        var largestPolygon: MKPolygon?
+        var largestArea = 0.0
+        
+        for geometry in geometries {
+            if let polygon = geometry as? MKPolygon {
+                let area = polygon.boundingMapRect.width * polygon.boundingMapRect.height
+                if area > largestArea {
+                    largestArea = area
+                    largestPolygon = polygon
+                }
+            } else if let multiPolygon = geometry as? MKMultiPolygon {
+                for polygon in multiPolygon.polygons {
+                    let area = polygon.boundingMapRect.width * polygon.boundingMapRect.height
+                    if area > largestArea {
+                        largestArea = area
+                        largestPolygon = polygon
+                    }
+                }
+            }
+        }
+        
+        // Use the center of the bounding box of the largest polygon
+        // This gives a more visually accurate centroid than averaging all points
+        if let polygon = largestPolygon {
+            let boundingBox = polygon.boundingMapRect
+            let centerPoint = MKMapPoint(x: boundingBox.midX, y: boundingBox.midY)
+            let centerCoordinate = centerPoint.coordinate
+            
+            return Coordinate(
+                latitude: centerCoordinate.latitude,
+                longitude: centerCoordinate.longitude
+            )
+        }
+        
+        // Fallback to averaging all points if no polygon found
         var totalLat = 0.0
         var totalLon = 0.0
         var pointCount = 0
@@ -407,7 +444,7 @@ final class CountryDataService {
             )
         }
         
-        // Fallback
+        // Final fallback
         return Coordinate(latitude: 0, longitude: 0)
     }
     

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/CountryMapBitmoji.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/CountryMapBitmoji.swift
@@ -1,0 +1,177 @@
+//
+//  CountryMapBitmoji.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 26.03.2026.
+//
+
+import SwiftUI
+import MapKit
+
+// MARK: - Map Annotation for Country Bitmoji
+
+class CountryBitmojiAnnotation: NSObject, MKAnnotation {
+    let countryID: String
+    let country: Country
+    let visit: Visit
+    
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(
+            latitude: country.centroid.latitude,
+            longitude: country.centroid.longitude
+        )
+    }
+    
+    var title: String? {
+        country.name
+    }
+    
+    init(country: Country, visit: Visit) {
+        self.countryID = country.id
+        self.country = country
+        self.visit = visit
+        super.init()
+    }
+}
+
+// MARK: - Annotation View
+
+class CountryBitmojiAnnotationView: MKAnnotationView {
+    static let identifier = "CountryBitmoji"
+    
+    private let containerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }()
+    
+    private let thumbnailImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.clipsToBounds = true
+        iv.layer.cornerRadius = 16
+        iv.layer.borderWidth = 2.5
+        iv.layer.borderColor = UIColor.white.cgColor
+        iv.layer.shadowColor = UIColor.black.cgColor
+        iv.layer.shadowOffset = CGSize(width: 0, height: 2)
+        iv.layer.shadowRadius = 4
+        iv.layer.shadowOpacity = 0.25
+        return iv
+    }()
+    
+    private let noteIconView: UIView = {
+        let container = UIView()
+        container.backgroundColor = .systemBlue
+        container.layer.cornerRadius = 16
+        container.layer.borderWidth = 2.5
+        container.layer.borderColor = UIColor.white.cgColor
+        container.layer.shadowColor = UIColor.black.cgColor
+        container.layer.shadowOffset = CGSize(width: 0, height: 2)
+        container.layer.shadowRadius = 4
+        container.layer.shadowOpacity = 0.25
+        
+        let icon = UIImageView(image: UIImage(systemName: "note.text"))
+        icon.tintColor = .white
+        icon.contentMode = .scaleAspectFit
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(icon)
+        
+        NSLayoutConstraint.activate([
+            icon.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            icon.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            icon.widthAnchor.constraint(equalToConstant: 16),
+            icon.heightAnchor.constraint(equalToConstant: 16)
+        ])
+        
+        return container
+    }()
+    
+    private let flagView: UIView = {
+        let container = UIView()
+        container.backgroundColor = .systemGreen
+        container.layer.cornerRadius = 16
+        container.layer.borderWidth = 2.5
+        container.layer.borderColor = UIColor.white.cgColor
+        container.layer.shadowColor = UIColor.black.cgColor
+        container.layer.shadowOffset = CGSize(width: 0, height: 2)
+        container.layer.shadowRadius = 4
+        container.layer.shadowOpacity = 0.25
+        return container
+    }()
+    
+    private let flagLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 20)
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupViews() {
+        frame = CGSize(width: 32, height: 32).asRect
+        centerOffset = CGPoint(x: 0, y: 0) // No offset - center the circle on the location
+        
+        addSubview(containerView)
+        containerView.frame = bounds
+        
+        thumbnailImageView.frame = CGRect(x: 0, y: 0, width: 32, height: 32)
+        noteIconView.frame = CGRect(x: 0, y: 0, width: 32, height: 32)
+        flagView.frame = CGRect(x: 0, y: 0, width: 32, height: 32)
+        
+        flagView.addSubview(flagLabel)
+        NSLayoutConstraint.activate([
+            flagLabel.centerXAnchor.constraint(equalTo: flagView.centerXAnchor),
+            flagLabel.centerYAnchor.constraint(equalTo: flagView.centerYAnchor)
+        ])
+        
+        containerView.addSubview(thumbnailImageView)
+        containerView.addSubview(noteIconView)
+        containerView.addSubview(flagView)
+        
+        // Enable tap
+        isEnabled = true
+        canShowCallout = false
+    }
+    
+    func configure(with annotation: CountryBitmojiAnnotation) {
+        // Always set the flag
+        flagLabel.text = annotation.country.flagEmoji
+        
+        if let firstPhoto = annotation.visit.photos.first,
+           let image = UIImage(data: firstPhoto.imageData) {
+            // Show photo thumbnail - this is the main feature!
+            thumbnailImageView.image = image
+            thumbnailImageView.isHidden = false
+            noteIconView.isHidden = true
+            flagView.isHidden = true
+        } else if !annotation.visit.notes.isEmpty {
+            // Show note icon when no photo
+            thumbnailImageView.isHidden = true
+            noteIconView.isHidden = false
+            flagView.isHidden = true
+        } else {
+            // Show flag emoji when no content
+            thumbnailImageView.isHidden = true
+            noteIconView.isHidden = true
+            flagView.isHidden = false
+        }
+    }
+}
+
+// MARK: - Helper Extension
+
+extension CGSize {
+    var asRect: CGRect {
+        CGRect(origin: .zero, size: self)
+    }
+}
+

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -16,8 +16,9 @@ struct MapScreen: View {
     @State private var showSyncStatus = true
     @State private var selectedCountryForSheet: SelectedCountry?
     @State private var selectedCountryForDetail: Country?
-    @State private var mapZoomLevel: MapZoomLevel = .world
+    @State private var mapZoomLevel: MapZoomLevel = .continent
     @State private var showingStats = true
+    @State private var expandedCountryPreview: CountryPreviewData?
 
     var body: some View {
         NavigationStack {
@@ -26,8 +27,12 @@ struct MapScreen: View {
                 MapContainerView(
                     visitedCountryIDs: appState.visitedCountryIDs,
                     zoomLevel: $mapZoomLevel,
+                    bitmojiAnnotations: getBitmojiAnnotations(),
                     onCountryTapped: { countryID in
-                        selectedCountryForSheet = SelectedCountry(id: countryID)
+                        handleCountryTap(countryID: countryID)
+                    },
+                    onBitmojiTapped: { countryID in
+                        handleBitmojiTap(countryID: countryID)
                     }
                 )
                 .edgesIgnoringSafeArea(.top)
@@ -83,6 +88,47 @@ struct MapScreen: View {
                         
                         Spacer()
                     }
+                }
+                
+                // Expanded preview bubble (when tapping a bitmoji)
+                if let preview = expandedCountryPreview {
+                    ZStack {
+                        // Tap outside to dismiss
+                        Color.clear
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                withAnimation {
+                                    expandedCountryPreview = nil
+                                }
+                            }
+                        
+                        VStack {
+                            Spacer()
+                            
+                            HStack {
+                                Spacer()
+                                
+                                CountryMapPreviewBubble(
+                                    country: preview.country,
+                                    visit: preview.visit,
+                                    onDismiss: {
+                                        expandedCountryPreview = nil
+                                    },
+                                    onViewDetails: {
+                                        selectedCountryForDetail = preview.country
+                                        expandedCountryPreview = nil
+                                    }
+                                )
+                                
+                                Spacer()
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.bottom, 32)
+                            // Prevent tap from passing through to the background
+                            .onTapGesture { }
+                        }
+                    }
+                    .transition(.opacity)
                 }
             }
             .navigationTitle("Map")
@@ -323,6 +369,51 @@ struct MapScreen: View {
     
     // MARK: - Data Management
     
+    private func handleCountryTap(countryID: String) {
+        // Close any expanded preview first
+        expandedCountryPreview = nil
+        
+        // Always show quick action sheet (for both visited and unvisited)
+        selectedCountryForSheet = SelectedCountry(id: countryID)
+    }
+    
+    private func handleBitmojiTap(countryID: String) {
+        // Close any open quick action sheet first
+        selectedCountryForSheet = nil
+        
+        // Show expanded preview when tapping a bitmoji
+        let countries = CountryDataService.shared.loadCountries()
+        guard let country = countries.first(where: { $0.id == countryID }) else {
+            return
+        }
+        
+        let visit = appState.visit(for: countryID)
+        
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+            expandedCountryPreview = CountryPreviewData(country: country, visit: visit)
+        }
+    }
+    
+    private func getBitmojiAnnotations() -> [CountryBitmojiAnnotation] {
+        // Only show bitmojis at continent zoom or closer to avoid clutter
+        guard mapZoomLevel != .world else {
+            return []
+        }
+        
+        let countries = CountryDataService.shared.loadCountries()
+        
+        let annotations: [CountryBitmojiAnnotation] = appState.visitedCountryIDs.compactMap { countryID -> CountryBitmojiAnnotation? in
+            guard let country = countries.first(where: { $0.id == countryID }) else {
+                return nil
+            }
+            
+            let visit = appState.visit(for: countryID)
+            return CountryBitmojiAnnotation(country: country, visit: visit)
+        }
+        
+        return annotations
+    }
+    
     private func handleAuthStateChange() async {
         guard authService.isSignedIn else {
             return
@@ -513,13 +604,17 @@ struct CountryQuickActionSheet: View {
 struct MapContainerView: View {
     let visitedCountryIDs: Set<String>
     @Binding var zoomLevel: MapZoomLevel
+    let bitmojiAnnotations: [CountryBitmojiAnnotation]
     let onCountryTapped: ((String) -> Void)?
+    let onBitmojiTapped: ((String) -> Void)?
     
     var body: some View {
         VisitedCountriesMapView(
             visitedCountryIDs: visitedCountryIDs,
             zoomLevel: $zoomLevel,
-            onCountryTapped: onCountryTapped
+            onCountryTapped: onCountryTapped,
+            bitmojiAnnotations: bitmojiAnnotations,
+            onBitmojiTapped: onBitmojiTapped
         )
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
@@ -42,14 +42,27 @@ struct VisitedCountriesMapView: UIViewRepresentable {
     let visitedCountryIDs: Set<String>
     @Binding var zoomLevel: MapZoomLevel
     var onCountryTapped: ((String) -> Void)?
+    var bitmojiAnnotations: [CountryBitmojiAnnotation] = []
+    var onBitmojiTapped: ((String) -> Void)?
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(visitedCountryIDs: visitedCountryIDs, zoomLevel: zoomLevel, onCountryTapped: onCountryTapped)
+        Coordinator(
+            visitedCountryIDs: visitedCountryIDs,
+            zoomLevel: zoomLevel,
+            onCountryTapped: onCountryTapped,
+            onBitmojiTapped: onBitmojiTapped
+        )
     }
 
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView(frame: .zero)
         mapView.delegate = context.coordinator
+        
+        // Register annotation view class
+        mapView.register(
+            CountryBitmojiAnnotationView.self,
+            forAnnotationViewWithReuseIdentifier: CountryBitmojiAnnotationView.identifier
+        )
         
         // Ensure proper rendering
         mapView.isOpaque = true
@@ -70,7 +83,7 @@ struct VisitedCountriesMapView: UIViewRepresentable {
 
         let region = MKCoordinateRegion(
             center: CLLocationCoordinate2D(latitude: 20, longitude: 0),
-            span: MKCoordinateSpan(latitudeDelta: 120, longitudeDelta: 120)
+            span: MKCoordinateSpan(latitudeDelta: 60, longitudeDelta: 60)
         )
         mapView.setRegion(region, animated: false)
 
@@ -100,8 +113,9 @@ struct VisitedCountriesMapView: UIViewRepresentable {
         // Update the coordinator's visited countries set
         context.coordinator.visitedCountryIDs = visitedCountryIDs
         
-        // Update the callback
+        // Update the callbacks
         context.coordinator.onCountryTapped = onCountryTapped
+        context.coordinator.onBitmojiTapped = onBitmojiTapped
         
         // Handle zoom level changes
         if context.coordinator.currentZoomLevel != zoomLevel {
@@ -123,27 +137,41 @@ struct VisitedCountriesMapView: UIViewRepresentable {
             mapView.setRegion(newRegion, animated: true)
         }
         
+        // Update annotations
+        updateAnnotations(in: mapView, coordinator: context.coordinator)
+        
         // OPTIMIZATION: Only update renderer colors if visited countries changed
         // Don't add/remove overlays - they're all on the map already
         if oldVisitedIDs != visitedCountryIDs, context.coordinator.allOverlaysLoaded {
             context.coordinator.updateRendererColors(for: mapView)
         }
     }
+    
+    private func updateAnnotations(in mapView: MKMapView, coordinator: Coordinator) {
+        // Remove old bitmoji annotations
+        let oldAnnotations = mapView.annotations.compactMap { $0 as? CountryBitmojiAnnotation }
+        mapView.removeAnnotations(oldAnnotations)
+        
+        // Add new bitmoji annotations
+        mapView.addAnnotations(bitmojiAnnotations)
+    }
 
     final class Coordinator: NSObject, MKMapViewDelegate {
         var visitedCountryIDs: Set<String>
         var overlaysByCountry: [String: [MKOverlay]] = [:]
         var onCountryTapped: ((String) -> Void)?
+        var onBitmojiTapped: ((String) -> Void)?
         var currentZoomLevel: MapZoomLevel
         var allOverlaysLoaded = false
         
         // Cache overlay -> countryID lookups for performance
         private var overlayCountryCache: [ObjectIdentifier: String] = [:]
 
-        init(visitedCountryIDs: Set<String>, zoomLevel: MapZoomLevel, onCountryTapped: ((String) -> Void)?) {
+        init(visitedCountryIDs: Set<String>, zoomLevel: MapZoomLevel, onCountryTapped: ((String) -> Void)?, onBitmojiTapped: ((String) -> Void)?) {
             self.visitedCountryIDs = visitedCountryIDs
             self.currentZoomLevel = zoomLevel
             self.onCountryTapped = onCountryTapped
+            self.onBitmojiTapped = onBitmojiTapped
         }
         
         // OPTIMIZATION: Update renderer colors without adding/removing overlays
@@ -162,7 +190,21 @@ struct VisitedCountriesMapView: UIViewRepresentable {
             let point = gesture.location(in: mapView)
             let coordinate = mapView.convert(point, toCoordinateFrom: mapView)
             
-            // FIX: If overlays haven't loaded yet, ensure they're loaded synchronously
+            // Check if we tapped on an annotation first
+            // If so, don't process country tap
+            for annotation in mapView.annotations {
+                if let annotationView = mapView.view(for: annotation) {
+                    let annotationPoint = mapView.convert(annotation.coordinate, toPointTo: mapView)
+                    let distance = hypot(point.x - annotationPoint.x, point.y - annotationPoint.y)
+                    
+                    // If tap is within 32pt of annotation (matching the new smaller size), ignore country tap
+                    if distance < 32 {
+                        return
+                    }
+                }
+            }
+            
+            // Ensure overlays are loaded before processing tap
             if overlaysByCountry.isEmpty {
                 overlaysByCountry = CountryBoundaryService.shared.getCountryOverlays()
                 let allOverlays = overlaysByCountry.values.flatMap { $0 }
@@ -227,6 +269,31 @@ struct VisitedCountriesMapView: UIViewRepresentable {
             }
 
             return MKOverlayRenderer(overlay: overlay)
+        }
+        
+        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+            guard let bitmojiAnnotation = annotation as? CountryBitmojiAnnotation else {
+                return nil
+            }
+            
+            let view = mapView.dequeueReusableAnnotationView(
+                withIdentifier: CountryBitmojiAnnotationView.identifier,
+                for: annotation
+            ) as? CountryBitmojiAnnotationView ?? CountryBitmojiAnnotationView(
+                annotation: annotation,
+                reuseIdentifier: CountryBitmojiAnnotationView.identifier
+            )
+            
+            view.configure(with: bitmojiAnnotation)
+            return view
+        }
+        
+        func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+            // Handle bitmoji tap
+            if let annotation = view.annotation as? CountryBitmojiAnnotation {
+                onBitmojiTapped?(annotation.countryID)
+                mapView.deselectAnnotation(annotation, animated: false)
+            }
         }
 
         func configure(renderer: MKOverlayPathRenderer, for overlay: MKOverlay) {


### PR DESCRIPTION
## Summary
Enhances the map experience by introducing preview bubbles and persistent bitmoji-style annotations for visited countries.

## Changes

### Map Preview Bubble
- added lightweight preview bubble for visited countries
- displays:
  - country info (flag, name, visit date)
  - photo thumbnail (if available)
  - notes preview (up to 3 lines)
- supports:
  - "View Details" navigation
  - dismiss via button or tap outside
- uses `.ultraThinMaterial` and spring animations for a native iOS feel

### Persistent Map Annotations (Bitmojis)
- added custom annotation views for visited countries
- shows:
  - photo thumbnail (if available)
  - note indicator (if notes exist)
  - flag fallback (if no content)
- annotations are always visible on the map (not only on tap)
- compact 32pt circular design for better visual clarity

### Interaction Model
- tapping a country polygon → opens existing quick action sheet
- tapping a bitmoji → opens preview bubble
- separates "action" vs "content preview" interactions

### Positioning Improvements
- implemented improved centroid calculation using largest polygon
- ensures accurate placement for countries with complex shapes or overseas territories

### Map Behavior Improvements
- changed default zoom from world → continent for better visibility
- ensures preview content is visible immediately on launch
- optimized tap handling for both overlays and annotations

### Performance Considerations
- uses lightweight annotation views
- avoids heavy state updates
- lazy loads preview data only when needed
- maintains smooth performance with many visited countries

## Result
- more engaging and visual map experience
- faster access to visit content (photos + notes)
- clearer interaction model (preview vs actions)
- improved map usability and aesthetics

## Why This Approach
Instead of showing content only after tapping, this introduces a more visual and exploratory experience:
- users can immediately see where they have content on the map
- preview bubbles provide quick context without leaving the map
- maintains performance while adding richer UI

## Related Issue
Closes #75