### PR TITLE
Fix unauthenticated sync retries and auth sync race

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import FirebaseAuth
 
 @MainActor
 final class SyncService {
@@ -33,6 +34,12 @@ final class SyncService {
     func syncVisits(withRetry: Bool = true) async throws {
         print("🌐 Network status check: isConnected = \(networkMonitor.isConnected)")
         
+        // AUTH GUARD: Don't sync if user is not authenticated
+        guard Auth.auth().currentUser != nil else {
+            print("⚠️ Sync skipped: User is not authenticated")
+            throw FirestoreVisitRepositoryError.notAuthenticated
+        }
+        
         // Prevent concurrent syncs
         guard !isSyncing else {
             print("⚠️ Sync already in progress, skipping")
@@ -54,7 +61,12 @@ final class SyncService {
                 print("✅ Sync complete on attempt \(attempt)")
                 return
             } catch let error as SyncError where error == .noConnection {
-                // Don't retry if no connection
+                // Don't retry network errors - user needs to fix connectivity
+                print("❌ Sync failed: No connection (will not retry)")
+                throw error
+            } catch let error as FirestoreVisitRepositoryError where error == .notAuthenticated {
+                // Don't retry auth errors - user needs to sign in
+                print("❌ Sync failed: User not authenticated (will not retry)")
                 throw error
             } catch {
                 lastError = error

--- a/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
@@ -134,6 +134,12 @@ final class AppState: ObservableObject {
                 syncStatus = .error("No internet connection", isOffline: true)
                 print("📊 Status set to: offline error")
             }
+        } catch let error as FirestoreVisitRepositoryError where error == .notAuthenticated {
+            print("⚠️ Sync failed: User not authenticated")
+            if showStatus {
+                syncStatus = .error("Please sign in to sync your data", isOffline: false)
+                print("📊 Status set to: auth error")
+            }
         } catch {
             print("⚠️ Sync failed: \(error)")
             let message = error.localizedDescription

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
@@ -191,8 +191,9 @@ struct AuthScreen: View {
             } else {
                 try await authService.signIn(email: email, password: password)
             }
-
-            await appState.syncWithCloud()
+            
+            // No need to manually call sync here - WorldTrackerIOSApp.handleAuthStateChange()
+            // will automatically trigger appState.handleSignIn() which includes sync
         } catch {
             withAnimation(.easeInOut(duration: 0.3)) {
                 errorMessage = friendlyErrorMessage(from: error)


### PR DESCRIPTION
## Summary
Fixes sync failures caused by unauthenticated sync attempts and removes a redundant sync trigger after authentication.

## Changes
- added an auth guard before sync starts
- prevented `notAuthenticated` errors from entering the retry loop
- added user-friendly handling for unauthenticated sync failures
- removed the redundant `syncWithCloud()` call from `AuthScreen`
- relied on auth state changes as the single source of truth for post-auth sync

## Result
- sync no longer retries when the user is not authenticated
- sign-in/sign-up no longer cause a brief auth-related sync error flash
- successful sync behavior remains unchanged
- logs are cleaner and sync flow is more predictable

## Notes
- no changes to Firestore schema
- no changes to authentication logic
- minimal fix with no architectural redesign

Closes #133