### PR TITLE
Reduce sensitive and verbose logging

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
@@ -179,7 +179,11 @@ final class FirestoreVisitRepository {
             try await deleteDocument(document.reference)
         }
         
+        #if DEBUG
         print("🗑️ Deleted \(snapshot.documents.count) visit document(s) for user \(userID)")
+        #else
+        print("🗑️ Deleted \(snapshot.documents.count) visit document(s)")
+        #endif
     }
 
     // MARK: - Helpers
@@ -216,8 +220,10 @@ final class FirestoreVisitRepository {
         let validatedWantToVisit: Bool
         
         if isVisited && wantToVisit {
+            #if DEBUG
             print("⚠️ Data integrity issue for \(countryId): both isVisited and wantToVisit are true")
             print("   Resolving by prioritizing visited state (clearing wantToVisit)")
+            #endif
             // Visited is more important state - it has a date and represents completed travel
             validatedIsVisited = true
             validatedWantToVisit = false
@@ -296,23 +302,31 @@ final class FirestoreVisitRepository {
             // Use source: .server to force network fetch, not cache
             ref.getDocuments(source: .server) { snapshot, error in
                 if let error {
+                    #if DEBUG
                     print("🔥 Firestore error: \(error)")
+                    #endif
                     continuation.resume(throwing: self.mapError(error))
                     return
                 }
 
                 guard let snapshot else {
+                    #if DEBUG
                     print("🔥 Firestore: No snapshot returned")
+                    #endif
                     continuation.resume(throwing: FirestoreVisitRepositoryError.invalidData)
                     return
                 }
                 
+                #if DEBUG
                 // Check if this data came from cache despite requesting server
                 print("🔥 Firestore snapshot: \(snapshot.documents.count) docs, metadata.isFromCache: \(snapshot.metadata.isFromCache)")
+                #endif
                 
                 // If we requested server but got cache, and we're offline, throw error
                 if snapshot.metadata.isFromCache {
+                    #if DEBUG
                     print("⚠️ Received cached data when server was requested - treating as offline")
+                    #endif
                     continuation.resume(throwing: FirestoreVisitRepositoryError.offline)
                     return
                 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/SwiftDataVisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/SwiftDataVisitRepository.swift
@@ -19,7 +19,9 @@ final class SwiftDataVisitRepository: VisitRepository {
     func visit(for countryId: String) throws -> Visit {
         if let entity = try fetchEntity(countryId: countryId) {
             let photos = decodePhotos(from: entity.photosData)
+            #if DEBUG
             print("📸 Loading visit for \(countryId) - photos count: \(photos.count)")
+            #endif
             return Visit(
                 countryId: entity.countryId,
                 isVisited: entity.isVisited,
@@ -32,7 +34,9 @@ final class SwiftDataVisitRepository: VisitRepository {
         }
 
         // default "not visited"
+        #if DEBUG
         print("📸 Creating new visit for \(countryId) - no existing entity")
+        #endif
         return Visit(countryId: countryId, isVisited: false, wantToVisit: false, visitedDate: nil, notes: "", photos: [], updatedAt: Date())
     }
     
@@ -98,17 +102,21 @@ final class SwiftDataVisitRepository: VisitRepository {
     func addPhoto(_ countryId: String, photo: VisitPhoto) throws {
         let entity = try fetchOrCreateEntity(countryId: countryId)
         var photos = decodePhotos(from: entity.photosData)
+        #if DEBUG
         print("📸 Before adding photo - Country: \(countryId), existing photos: \(photos.count)")
+        #endif
         photos.append(photo)
         entity.photosData = encodePhotos(photos)
         entity.updatedAt = Date()
         try context.save()
+        #if DEBUG
         print("📸 After saving photo - Country: \(countryId), total photos: \(photos.count)")
         
         // Verify save
         let verifyEntity = try fetchEntity(countryId: countryId)
         let verifyPhotos = decodePhotos(from: verifyEntity?.photosData)
         print("📸 Verification - Country: \(countryId), photos in DB: \(verifyPhotos.count)")
+        #endif
     }
     
     func removePhoto(_ countryId: String, photoId: UUID) throws {

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/NetworkMonitor.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/NetworkMonitor.swift
@@ -47,7 +47,9 @@ final class NetworkMonitor: ObservableObject, @unchecked Sendable {
                     self.connectionType = .unknown
                 }
                 
+                #if DEBUG
                 print("📡 Network status: \(self.isConnected ? "Connected" : "Disconnected") (\(self.connectionType))")
+                #endif
             }
         }
         

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
@@ -32,7 +32,9 @@ final class SyncService {
     }
 
     func syncVisits(withRetry: Bool = true) async throws {
+        #if DEBUG
         print("🌐 Network status check: isConnected = \(networkMonitor.isConnected)")
+        #endif
         
         // AUTH GUARD: Don't sync if user is not authenticated
         guard Auth.auth().currentUser != nil else {
@@ -42,14 +44,18 @@ final class SyncService {
         
         // Prevent concurrent syncs
         guard !isSyncing else {
+            #if DEBUG
             print("⚠️ Sync already in progress, skipping")
+            #endif
             return
         }
         
         isSyncing = true
         defer { isSyncing = false }
         
+        #if DEBUG
         print("🔄 Starting sync...")
+        #endif
         
         var lastError: Error?
         let attempts = withRetry ? maxRetries : 1
@@ -58,7 +64,9 @@ final class SyncService {
             do {
                 try await performSync()
                 lastSyncDate = Date()
+                #if DEBUG
                 print("✅ Sync complete on attempt \(attempt)")
+                #endif
                 return
             } catch let error as SyncError where error == .noConnection {
                 // Don't retry network errors - user needs to fix connectivity
@@ -70,11 +78,15 @@ final class SyncService {
                 throw error
             } catch {
                 lastError = error
+                #if DEBUG
                 print("⚠️ Sync attempt \(attempt) failed: \(error)")
+                #endif
                 
                 // If we have more attempts, wait before retrying
                 if attempt < attempts {
+                    #if DEBUG
                     print("⏳ Retrying in \(retryDelay) seconds...")
+                    #endif
                     try await Task.sleep(for: .seconds(retryDelay))
                     // Removed network check - let the actual sync attempt determine if there's a connection
                 }
@@ -133,13 +145,17 @@ final class SyncService {
                     break
                 }
             } catch {
+                #if DEBUG
                 print("⚠️ Failed to sync country \(countryId): \(error)")
+                #endif
                 errorCount += 1
                 // Continue with other countries
             }
         }
             
+            #if DEBUG
             print("✅ Sync complete: \(syncedCount) synced, \(errorCount) errors")
+            #endif
             
             // If there were any errors, throw an aggregate error
             if errorCount > 0 {
@@ -150,13 +166,17 @@ final class SyncService {
             let nsError = error as NSError
             let errorDescription = error.localizedDescription.lowercased()
             
+            #if DEBUG
             print("🔍 Error details - Domain: \(nsError.domain), Code: \(nsError.code)")
             print("🔍 Error description: \(error.localizedDescription)")
             print("🔍 NetworkMonitor.isConnected: \(networkMonitor.isConnected)")
+            #endif
             
             // Check if it's our custom offline error
             if let repoError = error as? FirestoreVisitRepositoryError, repoError == .offline {
+                #if DEBUG
                 print("❌ Firestore offline error detected (from cache check)")
+                #endif
                 throw SyncError.noConnection
             }
             
@@ -176,10 +196,14 @@ final class SyncService {
                                 !networkMonitor.isConnected
             
             if isNetworkError {
+                #if DEBUG
                 print("❌ Network error detected: \(error)")
+                #endif
                 throw SyncError.noConnection
             } else {
+                #if DEBUG
                 print("❌ Non-network error detected: \(error)")
+                #endif
                 // Re-throw other errors
                 throw error
             }

--- a/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
@@ -89,7 +89,9 @@ final class AppState: ObservableObject {
             self.visitedCountryIDs = visitedIDs
             self.wantToVisitCountryIDs = wantToVisitIDs
         } catch {
+            #if DEBUG
             print("⚠️ Failed to load visits from SwiftData: \(error)")
+            #endif
             objectWillChange.send()
             self.visits = [:]
             self.visitedCountryIDs = []
@@ -103,22 +105,30 @@ final class AppState: ObservableObject {
     
     func syncWithCloud(showStatus: Bool = true) async {
         guard let syncService else { 
+            #if DEBUG
             print("⚠️ Sync service not available")
+            #endif
             return 
         }
 
         // Prevent concurrent syncs
         guard !isSyncing else {
+            #if DEBUG
             print("⚠️ Sync already in progress")
+            #endif
             return
         }
         
+        #if DEBUG
         print("🔄 syncWithCloud called (showStatus: \(showStatus))")
+        #endif
         
         // Set syncing state immediately (before network check)
         if showStatus {
             syncStatus = .syncing
+            #if DEBUG
             print("📊 Status set to: syncing")
+            #endif
         }
 
         do {
@@ -126,38 +136,54 @@ final class AppState: ObservableObject {
             loadFromPersistence()
             if showStatus {
                 syncStatus = .success(Date())
+                #if DEBUG
                 print("✅ Status set to: success")
+                #endif
             }
         } catch let error as SyncError where error == .noConnection {
             print("⚠️ Sync failed: No connection")
             if showStatus {
                 syncStatus = .error("No internet connection", isOffline: true)
+                #if DEBUG
                 print("📊 Status set to: offline error")
+                #endif
             }
         } catch let error as FirestoreVisitRepositoryError where error == .notAuthenticated {
             print("⚠️ Sync failed: User not authenticated")
             if showStatus {
                 syncStatus = .error("Please sign in to sync your data", isOffline: false)
+                #if DEBUG
                 print("📊 Status set to: auth error")
+                #endif
             }
         } catch {
+            #if DEBUG
             print("⚠️ Sync failed: \(error)")
+            #endif
             let message = error.localizedDescription
             if showStatus {
                 syncStatus = .error(message, isOffline: false)
+                #if DEBUG
                 print("📊 Status set to: error - \(message)")
+                #endif
             }
         }
     }
     
     func retrySyncIfNeeded() async {
+        #if DEBUG
         print("🔁 retrySyncIfNeeded called, current status: \(syncStatus)")
+        #endif
         // Retry for any error state (including offline - user might have turned WiFi back on)
         if case .error = syncStatus {
+            #if DEBUG
             print("🔁 Retrying sync...")
+            #endif
             await syncWithCloud()
         } else {
+            #if DEBUG
             print("⚠️ Not retrying - not in error state")
+            #endif
         }
     }
     
@@ -226,7 +252,9 @@ final class AppState: ObservableObject {
                 await syncWithCloud(showStatus: false)
             }
         } catch {
+            #if DEBUG
             print("⚠️ Failed to persist setVisited: \(error)")
+            #endif
             
             // ROLLBACK: Restore old state to keep AppState consistent with DB
             objectWillChange.send()
@@ -278,7 +306,9 @@ final class AppState: ObservableObject {
                 await syncWithCloud(showStatus: false)
             }
         } catch {
+            #if DEBUG
             print("⚠️ Failed to persist setWantToVisit: \(error)")
+            #endif
             
             // ROLLBACK: Restore old state to keep AppState consistent with DB
             objectWillChange.send()
@@ -310,7 +340,9 @@ final class AppState: ObservableObject {
                 await syncWithCloud(showStatus: false)
             }
         } catch {
+            #if DEBUG
             print("⚠️ Failed to persist updateNotes: \(error)")
+            #endif
         }
     }
     
@@ -329,7 +361,9 @@ final class AppState: ObservableObject {
                 await syncWithCloud(showStatus: false)
             }
         } catch {
+            #if DEBUG
             print("⚠️ Failed to persist addPhoto: \(error)")
+            #endif
         }
     }
     
@@ -348,7 +382,9 @@ final class AppState: ObservableObject {
                 await syncWithCloud(showStatus: false)
             }
         } catch {
+            #if DEBUG
             print("⚠️ Failed to persist removePhoto: \(error)")
+            #endif
         }
     }
     
@@ -368,7 +404,9 @@ final class AppState: ObservableObject {
                     await syncWithCloud(showStatus: false)
                 }
             } catch {
+                #if DEBUG
                 print("⚠️ Failed to persist updatePhotoCaption: \(error)")
+                #endif
             }
         }
     }
@@ -396,7 +434,9 @@ final class AppState: ObservableObject {
             }
             clearLocalState()
         } catch {
+            #if DEBUG
             print("⚠️ Failed to clear local data after sign out: \(error)")
+            #endif
         }
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
@@ -13,7 +13,9 @@ struct StatsScreen: View {
     @StateObject private var vm = StatsViewModel()
     
     init() {
+        #if DEBUG
         print("🎨 StatsScreen initialized")
+        #endif
     }
     
     // MARK: - Computed stats
@@ -475,23 +477,33 @@ struct StatsScreen: View {
         private let service = CountryDataService.shared
         
         init() {
+            #if DEBUG
             print("📊 StatsViewModel initialized")
+            #endif
             load()
         }
         
         func load() {
+            #if DEBUG
             print("📊 StatsViewModel.load() called")
+            #endif
             isLoading = true
             
             // Load countries
             Task(priority: .userInitiated) {
+                #if DEBUG
                 print("📊 About to call CountryDataService.loadCountries()")
+                #endif
                 let loadedCountries = service.loadCountries()
+                #if DEBUG
                 print("📊 Received \(loadedCountries.count) countries from service")
+                #endif
                 
                 self.countries = loadedCountries
                 self.isLoading = false
+                #if DEBUG
                 print("📊 Updated StatsViewModel with \(loadedCountries.count) countries")
+                #endif
             }
         }
         


### PR DESCRIPTION
## Summary
Applies a small security/privacy hardening pass by reducing sensitive and overly verbose logging across the app.

## Changes
- wrapped user-identifying logs in `#if DEBUG`
- wrapped verbose Firebase / Firestore / sync error logs in `#if DEBUG`
- wrapped raw error prints in debug-only guards
- kept only high-level, user-safe logs in production paths

## Notes
- no business logic changes
- no architecture changes
- debug logging remains available in development builds
- production builds no longer expose as much internal detail through console logs

Closes #135 