### PR TITLE
Add travel comparison domain layer (Step 1)

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/xcshareddata/xcschemes/WorldTrackerIOS.xcscheme
+++ b/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/xcshareddata/xcschemes/WorldTrackerIOS.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "04ACF9D42F4E45E0004448FC"
+               BuildableName = "WorldTrackerIOS.app"
+               BlueprintName = "WorldTrackerIOS"
+               ReferencedContainer = "container:WorldTrackerIOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "04ACF9D42F4E45E0004448FC"
+            BuildableName = "WorldTrackerIOS.app"
+            BlueprintName = "WorldTrackerIOS"
+            ReferencedContainer = "container:WorldTrackerIOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "04ACF9D42F4E45E0004448FC"
+            BuildableName = "WorldTrackerIOS.app"
+            BlueprintName = "WorldTrackerIOS"
+            ReferencedContainer = "container:WorldTrackerIOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/TravelComparison.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/TravelComparison.swift
@@ -1,0 +1,118 @@
+//
+//  TravelComparison.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 13.04.2026.
+//
+
+import Foundation
+
+// MARK: - Comparison Mode
+
+/// Defines which aspect of travel data to compare
+enum ComparisonMode {
+    case visited      // Compare countries marked as visited
+    case wishlist     // Compare countries marked as want-to-visit
+}
+
+// MARK: - Comparison Result
+
+/// Represents the result of comparing two users' travel data
+struct TravelComparisonResult {
+    /// Countries that only you have (visited or wishlisted)
+    let yours: Set<String>
+    
+    /// Countries that both users share (both visited or both wishlisted)
+    let shared: Set<String>
+    
+    /// Countries that only the other user has (visited or wishlisted)
+    let theirs: Set<String>
+    
+    /// The mode used for this comparison (visited or wishlist)
+    let mode: ComparisonMode
+    
+    // MARK: - Computed Properties
+    
+    /// Total unique countries across both users
+    var totalUnique: Int {
+        yours.count + shared.count + theirs.count
+    }
+    
+    /// Percentage of overlap between the two users
+    /// Returns 0-100, or 0 if no countries exist
+    var overlapPercentage: Double {
+        guard totalUnique > 0 else { return 0 }
+        return Double(shared.count) / Double(totalUnique) * 100
+    }
+    
+    /// All country IDs involved in this comparison
+    var allCountryIds: Set<String> {
+        yours.union(shared).union(theirs)
+    }
+    
+    /// True if both users have no data for this comparison mode
+    var isEmpty: Bool {
+        totalUnique == 0
+    }
+}
+
+// MARK: - Detailed Comparison Result
+
+/// A comprehensive comparison containing both visited and wishlist comparisons
+struct DetailedTravelComparison {
+    /// Comparison of visited countries
+    let visitedComparison: TravelComparisonResult
+    
+    /// Comparison of wishlist countries
+    let wishlistComparison: TravelComparisonResult
+    
+    // MARK: - Computed Properties
+    
+    /// Total unique countries either user has interacted with (visited or wishlisted)
+    var totalUniqueCountries: Int {
+        let allIds = visitedComparison.allCountryIds.union(wishlistComparison.allCountryIds)
+        return allIds.count
+    }
+    
+    /// True if both users have no travel data at all
+    var isEmpty: Bool {
+        visitedComparison.isEmpty && wishlistComparison.isEmpty
+    }
+    
+    /// Countries that appear in both users' data but with different states
+    /// Example: You visited, they wishlisted (or vice versa)
+    var conflictingCountries: ConflictingCountries {
+        ConflictingCountries(
+            visitedComparison: visitedComparison,
+            wishlistComparison: wishlistComparison
+        )
+    }
+}
+
+// MARK: - Conflicting Countries Analysis
+
+/// Identifies countries where users have different travel states
+struct ConflictingCountries {
+    /// You visited, they wishlisted
+    let youVisitedTheyWishlisted: Set<String>
+    
+    /// They visited, you wishlisted
+    let theyVisitedYouWishlisted: Set<String>
+    
+    init(visitedComparison: TravelComparisonResult, wishlistComparison: TravelComparisonResult) {
+        // Your visited ∩ Their wishlist (you've been, they want to go)
+        let yourVisited = visitedComparison.yours.union(visitedComparison.shared)
+        let theirWishlist = wishlistComparison.theirs.union(wishlistComparison.shared)
+        self.youVisitedTheyWishlisted = yourVisited.intersection(theirWishlist)
+        
+        // Their visited ∩ Your wishlist (they've been, you want to go)
+        let theirVisited = visitedComparison.theirs.union(visitedComparison.shared)
+        let yourWishlist = wishlistComparison.yours.union(wishlistComparison.shared)
+        self.theyVisitedYouWishlisted = theirVisited.intersection(yourWishlist)
+    }
+    
+    /// True if there are any conflicting states
+    var hasConflicts: Bool {
+        !youVisitedTheyWishlisted.isEmpty || !theyVisitedYouWishlisted.isEmpty
+    }
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/TravelComparisonEngine.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/TravelComparisonEngine.swift
@@ -1,0 +1,165 @@
+//
+//  TravelComparisonEngine.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 13.04.2026.
+//
+
+import Foundation
+
+/// Pure comparison engine for analyzing travel data between two users
+/// No dependencies on Firestore, networking, or UI - only operates on Visit models
+struct TravelComparisonEngine {
+    
+    // MARK: - Public API
+    
+    /// Compare two users' travel data for a specific mode (visited or wishlist)
+    ///
+    /// - Parameters:
+    ///   - yourVisits: Your visit records (typically from AppState.visits)
+    ///   - theirVisits: The other user's visit records
+    ///   - mode: Whether to compare visited countries or wishlist countries
+    /// - Returns: Comparison result with yours/shared/theirs country sets
+    static func compare(
+        yourVisits: [String: Visit],
+        theirVisits: [String: Visit],
+        mode: ComparisonMode
+    ) -> TravelComparisonResult {
+        // Extract relevant country IDs based on mode
+        let yourCountries = extractCountryIds(from: yourVisits, mode: mode)
+        let theirCountries = extractCountryIds(from: theirVisits, mode: mode)
+        
+        // Compute set operations
+        let shared = yourCountries.intersection(theirCountries)
+        let yours = yourCountries.subtracting(shared)
+        let theirs = theirCountries.subtracting(shared)
+        
+        return TravelComparisonResult(
+            yours: yours,
+            shared: shared,
+            theirs: theirs,
+            mode: mode
+        )
+    }
+    
+    /// Perform a comprehensive comparison including both visited and wishlist data
+    ///
+    /// - Parameters:
+    ///   - yourVisits: Your visit records
+    ///   - theirVisits: The other user's visit records
+    /// - Returns: Detailed comparison with both visited and wishlist results
+    static func detailedCompare(
+        yourVisits: [String: Visit],
+        theirVisits: [String: Visit]
+    ) -> DetailedTravelComparison {
+        let visitedComparison = compare(
+            yourVisits: yourVisits,
+            theirVisits: theirVisits,
+            mode: .visited
+        )
+        
+        let wishlistComparison = compare(
+            yourVisits: yourVisits,
+            theirVisits: theirVisits,
+            mode: .wishlist
+        )
+        
+        return DetailedTravelComparison(
+            visitedComparison: visitedComparison,
+            wishlistComparison: wishlistComparison
+        )
+    }
+    
+    /// Compare using array of visits (convenience method)
+    ///
+    /// - Parameters:
+    ///   - yourVisits: Array of your visits
+    ///   - theirVisits: Array of their visits
+    ///   - mode: Comparison mode
+    /// - Returns: Comparison result
+    static func compare(
+        yourVisits: [Visit],
+        theirVisits: [Visit],
+        mode: ComparisonMode
+    ) -> TravelComparisonResult {
+        let yourDict = Dictionary(uniqueKeysWithValues: yourVisits.map { ($0.countryId, $0) })
+        let theirDict = Dictionary(uniqueKeysWithValues: theirVisits.map { ($0.countryId, $0) })
+        
+        return compare(
+            yourVisits: yourDict,
+            theirVisits: theirDict,
+            mode: mode
+        )
+    }
+    
+    /// Detailed comparison using array of visits (convenience method)
+    ///
+    /// - Parameters:
+    ///   - yourVisits: Array of your visits
+    ///   - theirVisits: Array of their visits
+    /// - Returns: Detailed comparison
+    static func detailedCompare(
+        yourVisits: [Visit],
+        theirVisits: [Visit]
+    ) -> DetailedTravelComparison {
+        let yourDict = Dictionary(uniqueKeysWithValues: yourVisits.map { ($0.countryId, $0) })
+        let theirDict = Dictionary(uniqueKeysWithValues: theirVisits.map { ($0.countryId, $0) })
+        
+        return detailedCompare(
+            yourVisits: yourDict,
+            theirVisits: theirDict
+        )
+    }
+    
+    // MARK: - Private Helpers
+    
+    /// Extract country IDs from visit data based on comparison mode
+    private static func extractCountryIds(
+        from visits: [String: Visit],
+        mode: ComparisonMode
+    ) -> Set<String> {
+        switch mode {
+        case .visited:
+            // Only countries where isVisited = true
+            return Set(visits.values.filter { $0.isVisited }.map { $0.countryId })
+            
+        case .wishlist:
+            // Only countries where wantToVisit = true
+            return Set(visits.values.filter { $0.wantToVisit }.map { $0.countryId })
+        }
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension TravelComparisonResult {
+    /// Check if a specific country belongs to you only
+    func isYours(_ countryId: String) -> Bool {
+        yours.contains(countryId)
+    }
+    
+    /// Check if a specific country is shared
+    func isShared(_ countryId: String) -> Bool {
+        shared.contains(countryId)
+    }
+    
+    /// Check if a specific country belongs to them only
+    func isTheirs(_ countryId: String) -> Bool {
+        theirs.contains(countryId)
+    }
+    
+    /// Get the ownership category for a country
+    func ownership(of countryId: String) -> ComparisonOwnership? {
+        if isYours(countryId) { return .yours }
+        if isShared(countryId) { return .shared }
+        if isTheirs(countryId) { return .theirs }
+        return nil
+    }
+}
+
+/// Represents who "owns" a country in a comparison
+enum ComparisonOwnership {
+    case yours
+    case shared
+    case theirs
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/TravelComparisonExample.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/TravelComparisonExample.swift
@@ -1,0 +1,158 @@
+//
+//  TravelComparisonExample.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 13.04.2026.
+//
+//  This file demonstrates how to use TravelComparisonEngine
+//  with existing AppState data. NOT meant to be compiled - just documentation.
+//
+
+/*
+
+// MARK: - Example 1: Simple Visited Comparison
+
+func compareVisitedCountries(with friendVisits: [String: Visit]) {
+    // Get your visits from AppState (already loaded)
+    let yourVisits = appState.visits
+    
+    // Compare visited countries
+    let comparison = TravelComparisonEngine.compare(
+        yourVisits: yourVisits,
+        theirVisits: friendVisits,
+        mode: .visited
+    )
+    
+    // Use the results
+    print("You visited \(comparison.yours.count) unique countries")
+    print("They visited \(comparison.theirs.count) unique countries")
+    print("You both visited \(comparison.shared.count) countries")
+    print("Overlap: \(comparison.overlapPercentage)%")
+    
+    // Example: Display shared countries
+    for countryId in comparison.shared {
+        print("Both visited: \(countryId)")
+    }
+}
+
+// MARK: - Example 2: Wishlist Comparison
+
+func compareWishlists(with friendVisits: [String: Visit]) {
+    let comparison = TravelComparisonEngine.compare(
+        yourVisits: appState.visits,
+        theirVisits: friendVisits,
+        mode: .wishlist
+    )
+    
+    print("Shared dream destinations: \(comparison.shared)")
+}
+
+// MARK: - Example 3: Full Comparison (Both Modes)
+
+func performFullComparison(with friendVisits: [String: Visit]) {
+    let detailed = TravelComparisonEngine.detailedCompare(
+        yourVisits: appState.visits,
+        theirVisits: friendVisits
+    )
+    
+    // Visited stats
+    let visited = detailed.visitedComparison
+    print("=== Visited Countries ===")
+    print("Only you: \(visited.yours.count)")
+    print("Both: \(visited.shared.count)")
+    print("Only them: \(visited.theirs.count)")
+    
+    // Wishlist stats
+    let wishlist = detailed.wishlistComparison
+    print("\n=== Wishlist ===")
+    print("Only you: \(wishlist.yours.count)")
+    print("Both: \(wishlist.shared.count)")
+    print("Only them: \(wishlist.theirs.count)")
+    
+    // Interesting insights
+    let conflicts = detailed.conflictingCountries
+    if conflicts.hasConflicts {
+        print("\n=== Travel Advice Opportunities ===")
+        print("You've been where they want to go: \(conflicts.youVisitedTheyWishlisted)")
+        print("They've been where you want to go: \(conflicts.theyVisitedYouWishlisted)")
+    }
+    
+    print("\nTotal unique countries: \(detailed.totalUniqueCountries)")
+}
+
+// MARK: - Example 4: Using with Arrays (from Firestore)
+
+func compareWithFetchedData(friendUserId: String) async throws {
+    // Fetch friend's visits (from Firestore, future implementation)
+    // let friendVisits = try await fetchVisitsForUser(friendUserId)
+    
+    // Convert your AppState visits to array if needed
+    let yourVisitsArray = Array(appState.visits.values)
+    
+    // Assuming friendVisits is [Visit]
+    // let comparison = TravelComparisonEngine.compare(
+    //     yourVisits: yourVisitsArray,
+    //     theirVisits: friendVisits,
+    //     mode: .visited
+    // )
+}
+
+// MARK: - Example 5: Check Individual Country Ownership
+
+func checkCountryOwnership(countryId: String, friendVisits: [String: Visit]) {
+    let comparison = TravelComparisonEngine.compare(
+        yourVisits: appState.visits,
+        theirVisits: friendVisits,
+        mode: .visited
+    )
+    
+    if comparison.isShared(countryId) {
+        print("\(countryId): Both of you have visited!")
+    } else if comparison.isYours(countryId) {
+        print("\(countryId): Only you have visited")
+    } else if comparison.isTheirs(countryId) {
+        print("\(countryId): Only they have visited")
+    } else {
+        print("\(countryId): Neither has visited")
+    }
+    
+    // Or use the ownership enum
+    switch comparison.ownership(of: countryId) {
+    case .yours:
+        print("Your exclusive destination")
+    case .shared:
+        print("Shared experience")
+    case .theirs:
+        print("Their exclusive destination")
+    case nil:
+        print("Not in comparison")
+    }
+}
+
+// MARK: - Example 6: Integration with Future UI
+
+// This is how a ViewModel might use it:
+@MainActor
+class ComparisonViewModel: ObservableObject {
+    @Published var comparison: DetailedTravelComparison?
+    @Published var isLoading = false
+    
+    func loadComparison(friendEmail: String) async {
+        isLoading = true
+        defer { isLoading = false }
+        
+        // Step 1: Fetch friend's data (not implemented yet)
+        // let friendVisits = try await fetchFriendVisits(email: friendEmail)
+        
+        // Step 2: Compare (already implemented!)
+        // let result = TravelComparisonEngine.detailedCompare(
+        //     yourVisits: appState.visits,
+        //     theirVisits: friendVisits
+        // )
+        
+        // Step 3: Store result
+        // self.comparison = result
+    }
+}
+
+*/


### PR DESCRIPTION
## Summary

Implements the core travel comparison domain layer to enable comparing visited and wishlist countries between two users.

This is the foundation for the comparison feature and does not include UI or backend integration yet.

## Changes

* add `TravelComparison` models for structured comparison results
* implement `TravelComparisonEngine` with pure comparison logic
* support both visited and wishlist comparison modes
* add conflict detection (visited vs wishlist mismatches)
* include computed properties (overlap percentage, totals, ownership helpers)
* add example usage 

## Notes

* pure Swift implementation (no Firebase or network dependencies)
* fully testable and reusable with any data source
* no changes to existing app logic or UI
* no authentication or Firestore changes in this phase

## Next Steps

* build UI prototype to visualize comparison results
* integrate with user data (profiles + Firestore) after validating UX

Closes #119 (Step 1)
