### PR TITLE
Add privacy-aware email lookup for travel comparison

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Services/FirestoreUserRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/FirestoreUserRepository.swift
@@ -14,6 +14,41 @@ import FirebaseFirestore
 final class FirestoreUserRepository {
     private let db = Firestore.firestore()
     
+    // MARK: - Profile Lookup Operations
+    
+    /// Find a user profile by email address
+    /// Only returns profiles where allowComparison is true
+    /// - Parameter email: The email address to search for
+    /// - Returns: UserProfile if found and comparison is allowed, nil otherwise
+    /// - Throws: FirestoreUserRepositoryError if query fails
+    func findProfileByEmail(_ email: String) async throws -> UserProfile? {
+        // Normalize email to lowercase for case-insensitive search
+        let normalizedEmail = email.lowercased().trimmingCharacters(in: .whitespaces)
+        
+        // Query for profiles with this email
+        let query = db.collectionGroup("profile")
+            .whereField("email", isEqualTo: normalizedEmail)
+            .whereField("allowComparison", isEqualTo: true)
+            .limit(to: 1)
+        
+        let snapshot = try await executeQuery(query)
+        
+        guard let document = snapshot.documents.first,
+              let data = document.data() as? [String: Any] else {
+            return nil
+        }
+        
+        // Extract userId from document path: users/{userId}/profile/data
+        let pathComponents = document.reference.path.components(separatedBy: "/")
+        guard pathComponents.count >= 2,
+              pathComponents[0] == "users" else {
+            throw FirestoreUserRepositoryError.invalidProfileData
+        }
+        let userId = pathComponents[1]
+        
+        return try mapProfile(userId: userId, data: data)
+    }
+    
     // MARK: - Current User Profile Operations
     
     /// Create or update the current user's profile
@@ -27,8 +62,11 @@ final class FirestoreUserRepository {
             throw FirestoreUserRepositoryError.invalidProfileData
         }
         
+        // Normalize email to lowercase for case-insensitive lookup
+        let normalizedEmail = profile.email.lowercased().trimmingCharacters(in: .whitespaces)
+        
         let data: [String: Any] = [
-            "email": profile.email,
+            "email": normalizedEmail,
             "allowComparison": profile.allowComparison,
             "createdAt": Timestamp(date: profile.createdAt),
             "updatedAt": Timestamp(date: Date())
@@ -122,6 +160,24 @@ final class FirestoreUserRepository {
     }
     
     // MARK: - Async Wrappers
+    
+    private func executeQuery(_ query: Query) async throws -> QuerySnapshot {
+        try await withCheckedThrowingContinuation { continuation in
+            query.getDocuments { snapshot, error in
+                if let error {
+                    continuation.resume(throwing: FirestoreUserRepositoryError.unknown(error))
+                    return
+                }
+                
+                guard let snapshot else {
+                    continuation.resume(throwing: FirestoreUserRepositoryError.documentNotFound)
+                    return
+                }
+                
+                continuation.resume(returning: snapshot)
+            }
+        }
+    }
     
     private func getDocument(from ref: DocumentReference) async throws -> DocumentSnapshot {
         try await withCheckedThrowingContinuation { continuation in

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
@@ -25,6 +25,12 @@ struct AccountScreen: View {
     @State private var isSavingComparison = false
     @State private var pendingComparisonValue: Bool?
     
+    // MARK: - Email Lookup Testing
+    
+    @State private var testEmail = ""
+    @State private var lookupResult: String?
+    @State private var isLookingUp = false
+    
     private let profileRepository = FirestoreUserRepository()
     
     // MARK: - Computed Properties for Travel Stats
@@ -251,6 +257,48 @@ struct AccountScreen: View {
             #endif
         }
     }
+    
+    // MARK: - Email Lookup Testing
+    
+    /// Test function to lookup a user by email
+    private func testEmailLookup() async {
+        await MainActor.run {
+            isLookingUp = true
+            lookupResult = nil
+        }
+        
+        do {
+            let profile = try await profileRepository.findProfileByEmail(testEmail)
+            
+            await MainActor.run {
+                if let profile {
+                    lookupResult = "✅ Found: \(profile.email)\nUser ID: \(profile.id)\nComparison allowed: \(profile.allowComparison)"
+                    
+                    #if DEBUG
+                    print("✅ Lookup successful: \(profile.email)")
+                    print("   User ID: \(profile.id)")
+                    print("   Allow comparison: \(profile.allowComparison)")
+                    #endif
+                } else {
+                    lookupResult = "❌ No user found with email '\(testEmail)' or they have disabled comparison"
+                    
+                    #if DEBUG
+                    print("❌ No profile found for: \(testEmail)")
+                    #endif
+                }
+                isLookingUp = false
+            }
+        } catch {
+            await MainActor.run {
+                lookupResult = "❌ Error: \(error.localizedDescription)"
+                isLookingUp = false
+                
+                #if DEBUG
+                print("❌ Lookup error: \(error.localizedDescription)")
+                #endif
+            }
+        }
+    }
 
     var body: some View {
         NavigationStack {
@@ -461,6 +509,51 @@ struct AccountScreen: View {
                 } footer: {
                     Text("When enabled, friends can compare their travel history with yours. Your travel data remains private when disabled.")
                 }
+                
+                // MARK: - Email Lookup Test Section (DEBUG ONLY)
+                #if DEBUG
+                Section {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Test Email Lookup")
+                            .font(.headline)
+                        
+                        TextField("Enter email to lookup", text: $testEmail)
+                            .textFieldStyle(.roundedBorder)
+                            .autocapitalization(.none)
+                            .keyboardType(.emailAddress)
+                            .disabled(isLookingUp)
+                        
+                        Button {
+                            Task {
+                                await testEmailLookup()
+                            }
+                        } label: {
+                            HStack {
+                                if isLookingUp {
+                                    ProgressView()
+                                        .scaleEffect(0.8)
+                                }
+                                Text(isLookingUp ? "Searching..." : "Lookup User")
+                            }
+                            .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(testEmail.isEmpty || isLookingUp)
+                        
+                        if let result = lookupResult {
+                            Text(result)
+                                .font(.caption)
+                                .foregroundStyle(result.hasPrefix("✅") ? .green : .red)
+                                .padding(.top, 4)
+                        }
+                    }
+                    .padding(.vertical, 8)
+                } header: {
+                    Text("Developer Tools")
+                } footer: {
+                    Text("This section is only visible in DEBUG builds. Test the email lookup functionality here.")
+                }
+                #endif
 
                 // MARK: - Settings Section
                 Section {


### PR DESCRIPTION
## Summary
Adds privacy-aware user lookup by email for the travel comparison feature.

## Changes
- extended `FirestoreUserRepository` with `findProfileByEmail(_:)`
- added case-insensitive email normalization before lookup
- implemented Firestore collection group query on `profile`
- filtered lookup results to users with `allowComparison == true`
- added AccountScreen support for testing the lookup flow in development
- created the required Firestore composite index for `email` + `allowComparison`

## Behavior
- lookup only returns users who explicitly enabled comparison
- lookup is case-insensitive
- leading/trailing whitespace is ignored
- returns `nil` when the user does not exist or comparison is disabled

## Security / Privacy
- travel visits remain owner-only
- profile lookup only exposes opted-in users
- no real-user comparison data is fetched yet
- no changes to comparison engine or map/list comparison logic in this step

## Notes
- all manual tests passed
- this step only adds discovery/lookup
- fetching another user's visits and wiring real comparison data will happen next

Part of #119