### PR TITLE
Fix tab state persistence: Always open to Map screen after sign-in

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
@@ -98,9 +98,10 @@ struct AuthGatedRootView: View {
             switch authService.authState {
             case .signedIn:
                 // User is authenticated - show main app
-                // Use stable ID that changes only when auth state changes to force recreation
+                // Use signInCounter to force recreation on each sign-in
+                // This ensures tab selection is reset to Map every time
                 RootTabView()
-                    .id("signed-in-\(authService.user?.uid ?? "unknown")")
+                    .id("signed-in-\(authService.signInCounter)")
                     .transition(.opacity)
                     .onAppear {
                         #if DEBUG

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
@@ -13,6 +13,10 @@ import FirebaseAuth
 final class AuthService: ObservableObject {
     @Published private(set) var user: User?
     @Published private(set) var authState: AuthState = .unknown
+    
+    /// Increments every time a user signs in
+    /// Used to force UI refresh and reset navigation state
+    @Published private(set) var signInCounter: Int = 0
 
     var userEmail: String {
         user?.email ?? "Unknown user"
@@ -31,6 +35,14 @@ final class AuthService: ObservableObject {
         
         // Get current user synchronously
         user = Auth.auth().currentUser
+        
+        // If user exists on init, increment counter (app launch while already signed in)
+        if user != nil {
+            signInCounter = 1
+            #if DEBUG
+            print("🔐 User already signed in on init - counter set to \(signInCounter)")
+            #endif
+        }
         
         // Schedule immediate state resolution
         Task { @MainActor in
@@ -63,10 +75,19 @@ final class AuthService: ObservableObject {
         authStateHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             guard let self else { return }
             
+            let wasSignedOut = self.user == nil
             self.user = user
             
             // Always update state based on user presence
             let newState: AuthState = user != nil ? .signedIn : .signedOut
+            
+            // Increment counter when transitioning from signed out to signed in
+            if wasSignedOut && newState == .signedIn {
+                self.signInCounter += 1
+                #if DEBUG
+                print("🔐 Sign-in detected - counter incremented to \(self.signInCounter)")
+                #endif
+            }
             
             // Only update if state actually changed
             if self.authState != newState {

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
@@ -6,12 +6,13 @@
 //
 
 import SwiftUI
+import FirebaseAuth
 
 struct RootTabView: View {
     @EnvironmentObject private var authService: AuthService
     @EnvironmentObject private var appState: AppState
     
-    // Track selected tab - always start on Map tab
+    // Track selected tab - always starts on Map when view is created
     @State private var selectedTab: Tab = .map
     
     enum Tab {
@@ -64,11 +65,8 @@ struct RootTabView: View {
             UITabBar.appearance().standardAppearance = appearance
             UITabBar.appearance().scrollEdgeAppearance = appearance
             
-            // CRITICAL: Reset to Map tab when view appears
-            selectedTab = .map
-            
             #if DEBUG
-            print("🗺️ RootTabView appeared - resetting to Map tab")
+            print("🗺️ RootTabView appeared with signInCounter=\(authService.signInCounter), selectedTab=\(selectedTab)")
             #endif
         }
         .task {


### PR DESCRIPTION
## Problem
The app was reopening to the last viewed tab (often Account) after users signed out and back in, instead of starting fresh at the Map screen. This occurred because SwiftUI's `TabView` was persisting state across view recreations.

## Solution
Implemented a sign-in counter in `AuthService` that increments on each sign-in event. The counter is used in `RootTabView`'s `.id()` modifier to force a complete view recreation whenever a user signs in, which resets all `@State` including the selected tab.

## Changes Made

### AuthService.swift
- ✅ Added `@Published signInCounter: Int` to track sign-in events
- ✅ Initialize counter to 1 if user already signed in on app launch
- ✅ Increment counter in auth state listener when transitioning from signed-out to signed-in

### WorldTrackerIOSApp.swift
- ✅ Updated `RootTabView` `.id()` from user UID to `signInCounter`
- ✅ Ensures view is recreated on every sign-in, not just user changes

### RootTabView.swift
- ✅ Simplified to use standard `@State` for `selectedTab` (defaults to `.map`)
- ✅ Added `import FirebaseAuth` for compiler compatibility
- ✅ Added debug logging to track sign-in counter

## Testing
Verified the following scenarios all open to Map screen:
- ✅ First-time sign-in
- ✅ Sign out from Account tab → Sign back in
- ✅ Sign out from any tab → Sign back in
- ✅ App restart while signed in

## Impact
- Improved user experience with consistent navigation flow
- Users always start at the Map screen after authentication
- No breaking changes to existing functionality

Closes #148 