### PR TITLE
  feat: redesign all screens with map-anchored color system and compare feature

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
@@ -155,24 +155,50 @@ struct AuthGatedRootView: View {
 private struct LoadingView: View {
     var body: some View {
         ZStack {
-            Color(.systemBackground)
+            Color.white
                 .ignoresSafeArea()
-            
-            VStack(spacing: 24) {
-                // App Logo
+
+            VStack(spacing: 32) {
                 AppLogoView()
-                
-                // App Name
-                Text("WorldTracker")
-                    .font(.system(size: 32, weight: .bold))
-                    .foregroundStyle(.primary)
-                
-                // Loading Indicator
-                ProgressView()
-                    .scaleEffect(1.2)
-                    .padding(.top, 8)
+
+                Text("WORLDTRACKER")
+                    .font(.custom("Inter", size: 16))
+                    .fontWeight(.black)
+                    .tracking(4)
+                    .foregroundStyle(.black)
+
+                LoadingSpinner()
+                    .padding(.top, 48)
+            }
+
+            VStack {
+                Spacer()
+                Text("YOUR WORLD, MAPPED.")
+                    .font(.custom("Inter", size: 10))
+                    .fontWeight(.medium)
+                    .tracking(3)
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .opacity(0.4)
+                    .padding(.bottom, 48)
             }
         }
+    }
+}
+
+private struct LoadingSpinner: View {
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        Circle()
+            .trim(from: 0.1, to: 0.9)
+            .stroke(Color.black, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+            .frame(width: 24, height: 24)
+            .rotationEffect(.degrees(rotation))
+            .onAppear {
+                withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+                    rotation = 360
+                }
+            }
     }
 }
 

--- a/WorldTrackerIOS/WorldTrackerIOS/DesignSystem/AppColors.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/DesignSystem/AppColors.swift
@@ -1,48 +1,37 @@
 import SwiftUI
 
 // MARK: - Color tokens
-// Source of truth: "WorldTracker Colorful / Vibrant & Elegant" design direction.
-// Map: theme2.jsx V2 object.
 
 extension Color {
 
     // MARK: Surfaces
-    /// Warm off-white — primary app background (#F6F2EC)
-    static let appPaper  = Color(hex: "#F6F2EC")
-    /// Near-white secondary surface (#FFFDFA)
-    static let appPaper2 = Color(hex: "#FFFDFA")
-    /// Pure white card surface
+    static let appPaper  = Color(hex: "#F7F7F7")
+    static let appPaper2 = Color(hex: "#F3F3F3")
     static let appCard   = Color.white
 
     // MARK: Ink / Text
-    /// Primary text — navy-charcoal (#1A1B2E)
-    static let appInk    = Color(hex: "#1A1B2E")
-    /// Secondary text (#2F3150)
-    static let appInk2   = Color(hex: "#2F3150")
-    /// Tertiary / subdued text (#6A6E8A)
-    static let appInk3   = Color(hex: "#6A6E8A")
+    static let appInk    = Color(hex: "#1b1b1b")
+    static let appInk2   = Color(hex: "#6B6B6B")
+    static let appInk3   = Color(hex: "#9E9E9E")
 
-    // MARK: Borders / Dividers
-    /// Soft warm border / divider line (#E9E4DB)
-    static let appLine   = Color(hex: "#E9E4DB")
+    // MARK: Borders
+    static let appLine   = Color(hex: "#E2E2E2")
 
-    // MARK: Brand Palette
-    /// Electric rose — primary CTA accent (#EC1763)
-    static let appRose   = Color(hex: "#EC1763")
-    /// Sky blue — primary navy-blue (#5568AF)
-    static let appSky    = Color(hex: "#5568AF")
-    /// Pale aqua — surface tint (#CEEAEE)
-    static let appAqua   = Color(hex: "#CEEAEE")
-    /// Lime — high-energy highlight (#CDD629)
-    static let appLime   = Color(hex: "#CDD629")
-    /// Blush — soft surface / badge background (#F8C9DD)
-    static let appBlush  = Color(hex: "#F8C9DD")
-    /// Sunset orange — warm energy (#F37826)
-    static let appSunset = Color(hex: "#F37826")
+    // MARK: Visited (red — matches map fill)
+    static let appVisited    = Color(hex: "#F9234D")
+    static let appVisitedBg  = Color(hex: "#FFF0F5")
 
-    // MARK: Status
-    /// Success green (#1E7F4E)
-    static let appSuccess = Color(hex: "#1E7F4E")
+    // MARK: Wishlist (sky blue — matches map fill)
+    static let appWishlist   = Color(hex: "#4A90D9")
+    static let appWishlistBg = Color(hex: "#EAF6FE")
+
+    // MARK: Achievement (gold)
+    static let appGold   = Color(hex: "#E6A817")
+    static let appGoldBg = Color(hex: "#FFF9E6")
+
+    // MARK: Success / confirmed (green)
+    static let appSuccess   = Color(hex: "#2E9E5B")
+    static let appSuccessBg = Color(hex: "#F0FFF4")
 }
 
 // MARK: - Hex initializer

--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
@@ -80,6 +80,27 @@ final class FirestoreVisitRepository {
         )
     }
 
+    /// Writes visit metadata atomically in a single Firestore write.
+    /// Photos are intentionally excluded — Firestore has a 1 MB document limit and
+    /// Base64-encoded images blow past it quickly. Photos live in local storage only.
+    func setVisit(_ visit: Visit) async throws {
+        let userID = try requireUserID()
+        let ref = db.collection("users")
+            .document(userID)
+            .collection("visits")
+            .document(visit.countryId)
+
+        let data: [String: Any] = [
+            "isVisited": visit.isVisited,
+            "wantToVisit": visit.wantToVisit,
+            "visitedDate": visit.visitedDate as Any,
+            "notes": visit.notes,
+            "updatedAt": Timestamp(date: visit.updatedAt)
+        ]
+
+        try await setData(data, for: ref)
+    }
+
     func updateNotes(_ countryId: String, notes: String) async throws {
         let userID = try requireUserID()
 

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
@@ -21,6 +21,13 @@ final class AuthService: ObservableObject {
     var userEmail: String {
         user?.email ?? "Unknown user"
     }
+
+    var displayName: String {
+        if let name = user?.displayName, !name.trimmingCharacters(in: .whitespaces).isEmpty {
+            return name
+        }
+        return userEmail
+    }
     
     private var authStateHandle: AuthStateDidChangeListenerHandle?
 
@@ -109,8 +116,23 @@ final class AuthService: ObservableObject {
         user != nil
     }
 
-    func signUp(email: String, password: String) async throws {
-        _ = try await Auth.auth().createUser(withEmail: email, password: password)
+    func signUp(email: String, password: String, firstName: String, lastName: String) async throws {
+        let result = try await Auth.auth().createUser(withEmail: email, password: password)
+
+        // Set Firebase Auth display name so it's available immediately without a Firestore fetch
+        let changeRequest = result.user.createProfileChangeRequest()
+        changeRequest.displayName = "\(firstName) \(lastName)".trimmingCharacters(in: .whitespaces)
+        try? await changeRequest.commitChanges()
+
+        // Persist name + email in Firestore profile
+        let repo = FirestoreUserRepository()
+        let profile = UserProfile(
+            userId: result.user.uid,
+            email: email.lowercased().trimmingCharacters(in: .whitespaces),
+            firstName: firstName,
+            lastName: lastName
+        )
+        try? await repo.createOrUpdateProfile(profile)
     }
 
     func signIn(email: String, password: String) async throws {

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/ChangePasswordView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/ChangePasswordView.swift
@@ -10,17 +10,18 @@ import SwiftUI
 struct ChangePasswordView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var authService: AuthService
-    
+
     @State private var currentPassword = ""
     @State private var newPassword = ""
     @State private var confirmPassword = ""
     @State private var errorMessage: String?
-    @State private var successMessage: String?
     @State private var isSubmitting = false
-    
+    @State private var showCurrent = false
+    @State private var showNew = false
+    @State private var showConfirm = false
+
     // MARK: - Validation
-    
-    /// Check if the form is valid and ready for submission
+
     private var isFormValid: Bool {
         !currentPassword.isEmpty &&
         !newPassword.isEmpty &&
@@ -30,185 +31,234 @@ struct ChangePasswordView: View {
         currentPassword != newPassword &&
         !isSubmitting
     }
-    
-    /// Validation error message shown below password fields
+
+    private var passwordsMatch: Bool {
+        !newPassword.isEmpty && !confirmPassword.isEmpty && newPassword == confirmPassword
+    }
+
     private var validationHint: String? {
-        // Don't show hints until user starts typing
-        guard !newPassword.isEmpty || !confirmPassword.isEmpty else {
-            return nil
-        }
-        
+        guard !newPassword.isEmpty || !confirmPassword.isEmpty else { return nil }
         if newPassword.count > 0 && newPassword.count < 6 {
             return "Password must be at least 6 characters"
         }
-        
         if !confirmPassword.isEmpty && newPassword != confirmPassword {
             return "Passwords do not match"
         }
-        
         if !newPassword.isEmpty && !currentPassword.isEmpty && newPassword == currentPassword {
             return "New password must be different from current password"
         }
-        
         return nil
     }
-    
+
     // MARK: - Body
-    
+
     var body: some View {
-        NavigationStack {
-            Form {
-                // MARK: - Current Password Section
-                Section {
-                    SecureField("Current Password", text: $currentPassword)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                } header: {
-                    Text("Verify Identity")
-                } footer: {
-                    Text("Enter your current password to continue")
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Change Password")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                Spacer()
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 26))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
                 }
-                
-                // MARK: - New Password Section
-                Section {
-                    SecureField("New Password", text: $newPassword)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                    
-                    SecureField("Confirm New Password", text: $confirmPassword)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                } header: {
-                    Text("New Password")
-                } footer: {
-                    if let validationHint {
-                        Text(validationHint)
-                            .foregroundStyle(.orange)
-                    } else {
-                        Text("Password must be at least 6 characters")
-                    }
-                }
-                
-                // MARK: - Submit Section
-                Section {
-                    Button {
-                        Task {
-                            await changePassword()
+                .buttonStyle(.plain)
+                .disabled(isSubmitting)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 20)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+
+                    // MARK: Verify identity
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("VERIFY IDENTITY")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .tracking(0.8)
+                            .padding(.horizontal, 4)
+
+                        VStack(spacing: 0) {
+                            passwordField(
+                                placeholder: "Current Password",
+                                text: $currentPassword,
+                                show: $showCurrent
+                            )
                         }
-                    } label: {
-                        HStack {
-                            if isSubmitting {
-                                ProgressView()
-                                    .padding(.trailing, 8)
+                        .background(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+
+                        Text("Enter your current password to continue")
+                            .font(.system(size: 12))
+                            .foregroundStyle(Color(hex: "#BBBBBB"))
+                            .padding(.horizontal, 4)
+                    }
+
+                    // MARK: New password
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("NEW PASSWORD")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .tracking(0.8)
+                            .padding(.horizontal, 4)
+
+                        VStack(spacing: 0) {
+                            passwordField(
+                                placeholder: "New Password",
+                                text: $newPassword,
+                                show: $showNew
+                            )
+
+                            Divider().padding(.horizontal, 16)
+
+                            passwordField(
+                                placeholder: "Confirm New Password",
+                                text: $confirmPassword,
+                                show: $showConfirm
+                            )
+
+                            if !newPassword.isEmpty || !confirmPassword.isEmpty {
+                                Divider().padding(.horizontal, 16)
+
+                                HStack(spacing: 8) {
+                                    Image(systemName: passwordsMatch ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                        .font(.system(size: 15))
+                                        .foregroundStyle(passwordsMatch ? Color(hex: "#2E9E5B") : Color(hex: "#CCCCCC"))
+                                    Text(passwordsMatch ? "Passwords match" : (validationHint ?? "Passwords do not match"))
+                                        .font(.system(size: 13))
+                                        .foregroundStyle(passwordsMatch ? Color(hex: "#2E9E5B") : Color(hex: "#9E9E9E"))
+                                }
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 14)
                             }
-                            Text(isSubmitting ? "Changing Password..." : "Change Password")
                         }
-                        .frame(maxWidth: .infinity)
+                        .background(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+
+                        Text("Password must be at least 6 characters")
+                            .font(.system(size: 12))
+                            .foregroundStyle(Color(hex: "#BBBBBB"))
+                            .padding(.horizontal, 4)
                     }
-                    .disabled(!isFormValid)
-                }
-                
-                // MARK: - Error Section
-                if let errorMessage {
-                    Section {
+
+                    // MARK: Error
+                    if let errorMessage {
                         Text(errorMessage)
+                            .font(.system(size: 13))
                             .foregroundStyle(.red)
-                    } header: {
-                        Text("Error")
+                            .padding(.horizontal, 4)
                     }
-                }
-                
-                // MARK: - Success Section
-                if let successMessage {
-                    Section {
-                        HStack(spacing: 8) {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
-                            Text(successMessage)
-                                .foregroundStyle(.green)
+
+                    // MARK: Actions
+                    VStack(spacing: 14) {
+                        Button {
+                            Task { await changePassword() }
+                        } label: {
+                            HStack(spacing: 8) {
+                                if isSubmitting {
+                                    ProgressView()
+                                        .tint(.white)
+                                }
+                                Text(isSubmitting ? "Changing Password..." : "Change Password")
+                                    .font(.system(size: 16, weight: .bold))
+                                    .foregroundStyle(.white)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 18)
+                            .background(isFormValid ? Color(hex: "#1b1b1b") : Color(hex: "#CCCCCC"))
+                            .clipShape(Capsule())
                         }
+                        .buttonStyle(.plain)
+                        .disabled(!isFormValid)
+
+                        Button { dismiss() } label: {
+                            Text("Cancel")
+                                .font(.system(size: 15))
+                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(isSubmitting)
                     }
                 }
-            }
-            .navigationTitle("Change Password")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        dismiss()
-                    }
-                    .disabled(isSubmitting)
-                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 32)
             }
         }
+        .background(Color(hex: "#F7F7F7"))
     }
-    
-    // MARK: - Password Change Logic
-    
-    /// Execute the password change workflow
-    /// 1. Reauthenticate with current password
-    /// 2. Update to new password
-    /// 3. Show success and dismiss
-    private func changePassword() async {
-        // Clear previous messages
-        errorMessage = nil
-        successMessage = nil
-        isSubmitting = true
-        
-        defer {
-            isSubmitting = false
+
+    // MARK: - Password Field
+
+    private func passwordField(placeholder: String, text: Binding<String>, show: Binding<Bool>) -> some View {
+        HStack(spacing: 12) {
+            Group {
+                if show.wrappedValue {
+                    TextField(placeholder, text: text)
+                } else {
+                    SecureField(placeholder, text: text)
+                }
+            }
+            .font(.system(size: 15))
+            .foregroundStyle(Color(hex: "#1b1b1b"))
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+
+            Button {
+                show.wrappedValue.toggle()
+            } label: {
+                Image(systemName: show.wrappedValue ? "eye.fill" : "eye.slash.fill")
+                    .font(.system(size: 16))
+                    .foregroundStyle(show.wrappedValue ? Color(hex: "#6B6B6B") : Color(hex: "#CCCCCC"))
+            }
+            .buttonStyle(.plain)
         }
-        
+        .padding(.horizontal, 16)
+        .padding(.vertical, 16)
+    }
+
+    // MARK: - Password Change Logic
+
+    private func changePassword() async {
+        errorMessage = nil
+        isSubmitting = true
+        defer { isSubmitting = false }
+
         do {
-            // Step 1: Reauthenticate with current password
             try await authService.reauthenticate(currentPassword: currentPassword)
-            
-            // Step 2: Update to new password
             try await authService.updatePassword(newPassword: newPassword)
-            
-            // Success
-            successMessage = "Password changed successfully!"
-            
-            // Auto-dismiss after brief success message (1.5 seconds)
             try? await Task.sleep(for: .seconds(1.5))
             dismiss()
-            
         } catch let error as NSError {
-            // Map Firebase errors to user-friendly messages
             errorMessage = friendlyErrorMessage(from: error)
         }
     }
-    
+
     // MARK: - Error Handling
-    
-    /// Convert Firebase error codes to user-friendly messages
-    /// - Parameter error: The error from Firebase Auth
-    /// - Returns: A user-friendly error message
+
     private func friendlyErrorMessage(from error: NSError) -> String {
-        // Firebase Auth errors use domain "FIRAuthErrorDomain"
         if error.domain == "FIRAuthErrorDomain" {
             switch error.code {
-            case 17009: // ERROR_WRONG_PASSWORD
+            case 17009, 17004, 17999:
                 return "Current password is incorrect"
-            case 17004: // ERROR_INVALID_EMAIL (but often means wrong password in reauthentication)
-                return "Current password is incorrect"
-            case 17026: // ERROR_WEAK_PASSWORD
+            case 17026:
                 return "New password is too weak. Please choose a stronger password"
-            case 17020: // ERROR_NETWORK_REQUEST_FAILED
+            case 17020:
                 return "Network error. Please check your connection and try again"
-            case 17999: // ERROR_INVALID_CREDENTIAL
-                return "Current password is incorrect"
-            case 17011: // ERROR_USER_NOT_FOUND
+            case 17011:
                 return "User session expired. Please sign in again"
-            case 17014: // ERROR_USER_MISMATCH
+            case 17014:
                 return "Authentication error. Please try again"
-            case 17995: // ERROR_REQUIRES_RECENT_LOGIN
+            case 17995:
                 return "Session expired. Please sign out and sign back in"
             default:
-                // For unknown Firebase errors, check the error message
                 let message = error.localizedDescription.lowercased()
-                
-                // Parse common error messages
                 if message.contains("credential") && (message.contains("malformed") || message.contains("expired")) {
                     return "Current password is incorrect"
                 } else if message.contains("password") && message.contains("weak") {
@@ -216,12 +266,10 @@ struct ChangePasswordView: View {
                 } else if message.contains("network") || message.contains("connection") {
                     return "Network error. Please check your connection and try again"
                 } else {
-                    // Generic fallback without the confusing "Failed to change password:" prefix
                     return "Unable to change password. Please try again or contact support"
                 }
             }
         } else {
-            // For non-Firebase errors
             return error.localizedDescription
         }
     }

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/ComparisonView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/ComparisonView.swift
@@ -13,18 +13,12 @@ struct ComparisonView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var authService: AuthService
     @StateObject private var viewModel = ComparisonViewModel()
-    @State private var displayMode: DisplayMode = .list
-    @State private var mapZoomLevel: MapZoomLevel = .continent
     @State private var lastUserId: String? = nil
-    
-    enum DisplayMode {
-        case list
-        case map
-    }
-    
+
     var body: some View {
         NavigationStack {
-            Group {
+            ZStack {
+                Color(hex: "#F7F7F7").ignoresSafeArea()
                 switch viewModel.state {
                 case .idle:
                     searchView
@@ -36,465 +30,502 @@ struct ComparisonView: View {
                     errorView(message: message)
                 }
             }
-            .navigationTitle("Travel Comparison")
+            .navigationTitle(navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if case .loaded = viewModel.state {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button { viewModel.resetToIdle() } label: {
+                            Image(systemName: "chevron.left")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                        }
+                    }
+                }
+            }
             .onAppear {
-                // Check if user has changed (sign out / sign in / account switch)
                 let currentUserId = authService.user?.uid
-                
                 if lastUserId != currentUserId {
-                    // User changed - reset to idle state
                     lastUserId = currentUserId
                     viewModel.resetToIdle()
                 }
             }
             .onChange(of: appState.visits) { _, newVisits in
-                // Only reload if we have a comparison loaded
                 if case .loaded = viewModel.state {
                     viewModel.reloadComparison(yourVisits: newVisits)
                 }
             }
         }
     }
-    
-    // MARK: - State Views
-    
-    /// Initial state: Search for a user to compare with
+
+    private var navigationTitle: String {
+        if case .loaded = viewModel.state { return "Travel comparison" }
+        return "Compare"
+    }
+
+    // MARK: - Search (Idle) View
+
     private var searchView: some View {
-        VStack(spacing: 24) {
-            Spacer()
-            
-            // Icon and title
+        ScrollView {
             VStack(spacing: 16) {
-                Image(systemName: "person.2.fill")
-                    .font(.system(size: 64))
-                    .foregroundStyle(.blue)
-                
-                Text("Compare Travel Experiences")
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                
-                Text("Enter a friend's email to see how your travels compare")
-                    .font(.body)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 32)
-            }
-            .padding(.bottom, 32)
-            
-            // Search field
-            VStack(spacing: 16) {
-                HStack(spacing: 12) {
-                    Image(systemName: "envelope.fill")
-                        .foregroundStyle(.secondary)
-                    
-                    TextField("friend@example.com", text: $viewModel.emailToCompare)
-                        .textFieldStyle(.plain)
-                        .autocapitalization(.none)
-                        .keyboardType(.emailAddress)
-                        .submitLabel(.search)
-                        .onSubmit {
-                            Task {
-                                await viewModel.searchUser(yourVisits: appState.visits)
+                heroEntryCard
+                    .padding(.horizontal, 16)
+                    .padding(.top, 20)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("FRIEND'S EMAIL")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .tracking(0.8)
+
+                    HStack(spacing: 12) {
+                        Image(systemName: "envelope")
+                            .font(.system(size: 15))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                        TextField("friend@example.com", text: $viewModel.emailToCompare)
+                            .font(.system(size: 15))
+                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .textInputAutocapitalization(.never)
+                            .keyboardType(.emailAddress)
+                            .autocorrectionDisabled()
+                            .submitLabel(.search)
+                            .onSubmit {
+                                Task { await viewModel.searchUser(yourVisits: appState.visits) }
                             }
-                        }
-                }
-                .padding()
-                .background(.regularMaterial)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                
-                Button {
-                    Task {
-                        await viewModel.searchUser(yourVisits: appState.visits)
                     }
-                } label: {
-                    Text("Compare")
-                        .font(.headline)
-                        .frame(maxWidth: .infinity)
-                        .padding()
+                    .padding(.horizontal, 16)
+                    .frame(height: 50)
+                    .background(Color(hex: "#F3F3F3"))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                    Button {
+                        Task { await viewModel.searchUser(yourVisits: appState.visits) }
+                    } label: {
+                        Text("Compare travels")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 52)
+                            .background(Color(hex: "#1b1b1b"))
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                    }
+                    .disabled(viewModel.emailToCompare.isEmpty)
+                    .opacity(viewModel.emailToCompare.isEmpty ? 0.5 : 1)
                 }
-                .buttonStyle(.borderedProminent)
-                .disabled(viewModel.emailToCompare.isEmpty)
-            }
-            .padding(.horizontal, 32)
-            
-            Spacer()
-            
-            // Privacy note
-            VStack(spacing: 8) {
-                HStack(spacing: 8) {
+                .padding(16)
+                .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+                .padding(.horizontal, 16)
+
+                HStack(spacing: 6) {
                     Image(systemName: "lock.fill")
-                        .font(.caption)
-                    Text("Privacy Protected")
-                        .font(.caption)
-                        .fontWeight(.medium)
+                        .font(.system(size: 11))
+                    Text("Only works with users who have enabled comparison in their privacy settings")
+                        .font(.system(size: 12))
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-                .foregroundStyle(.secondary)
-                
-                Text("You can only compare with users who have enabled comparison in their account settings")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 32)
+                .foregroundStyle(Color(hex: "#9E9E9E"))
+                .padding(.horizontal, 24)
+                .padding(.bottom, 32)
             }
-            .padding(.bottom, 32)
         }
     }
-    
-    /// Loading state: Fetching user data
+
+    private var heroEntryCard: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack(spacing: -12) {
+                avatarCircle(initials: myInitials, bg: Color(hex: "#3A3A3A"))
+                avatarCircle(initials: "?", bg: Color(hex: "#1b1b1b"))
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Compare your travels\nwith anyone")
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundStyle(.white)
+                Text("See countries you've both been to, where you'd love to go together, and trips worth planning.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.white.opacity(0.65))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(Color(hex: "#1b1b1b"))
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+    }
+
+    // MARK: - Loading View
+
     private var loadingView: some View {
-        VStack(spacing: 24) {
-            Spacer()
-            
+        VStack(spacing: 16) {
             ProgressView()
-                .scaleEffect(1.5)
-            
+                .scaleEffect(1.3)
             Text("Loading comparison...")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-                .padding(.top)
-            
-            Spacer()
+                .font(.system(size: 14))
+                .foregroundStyle(Color(hex: "#9E9E9E"))
         }
     }
-    
-    /// Error state: Something went wrong
+
+    // MARK: - Error View
+
     private func errorView(message: String) -> some View {
-        VStack(spacing: 24) {
-            Spacer()
-            
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 64))
-                .foregroundStyle(.red)
-            
-            Text("Unable to Compare")
-                .font(.title2)
-                .fontWeight(.semibold)
-            
-            Text(message)
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 32)
-            
-            Button {
-                viewModel.resetToIdle()
-            } label: {
-                Text("Try Again")
-                    .font(.headline)
-                    .padding(.horizontal, 32)
-                    .padding(.vertical, 12)
-            }
-            .buttonStyle(.borderedProminent)
-            .padding(.top)
-            
-            Spacer()
-        }
-    }
-    
-    /// Loaded state: Show comparison results
-    private var resultsView: some View {
-        VStack(spacing: 0) {
-            // Compared user info bar
-            if let profile = viewModel.comparedUserProfile {
-                comparedUserInfoBar(profile: profile)
-            }
-            
-            // Display Mode Picker (List vs Map)
-            Picker("Display Mode", selection: $displayMode) {
-                Text("List").tag(DisplayMode.list)
-                Text("Map").tag(DisplayMode.map)
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal)
-            .padding(.top, 8)
-            
-            // Mode Picker (Visited vs Wishlist)
-            Picker("Comparison Mode", selection: $viewModel.selectedMode) {
-                Text("Visited").tag(ComparisonMode.visited)
-                Text("Wishlist").tag(ComparisonMode.wishlist)
-            }
-            .pickerStyle(.segmented)
-            .padding()
-            
-            // Content based on display mode
-            if displayMode == .list {
-                listView
-            } else {
-                mapView
-            }
-        }
-    }
-    
-    /// Info bar showing who we're comparing with
-    private func comparedUserInfoBar(profile: UserProfile) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundStyle(.green)
-            
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Comparing with")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                Text(profile.email)
-                    .font(.caption)
-                    .fontWeight(.medium)
-            }
-            
-            Spacer()
-            
-            Button {
-                viewModel.resetToIdle()
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .padding(.horizontal)
-        .padding(.vertical, 12)
-        .background(.regularMaterial)
-    }
-    
-    // MARK: - List View
-    
-    private var listView: some View {
-        VStack(spacing: 0) {
-            // Stats Summary Card
-            statsCard
-                .padding(.horizontal)
-                .padding(.bottom, 8)
-            
-            // Main Comparison List
-            List {
-                // Section 1: Yours
-                if !viewModel.currentComparison.yours.isEmpty {
-                    Section {
-                        ForEach(viewModel.yourCountries, id: \.id) { country in
-                            CountryRow(country: country, badge: .yours)
-                        }
-                    } header: {
-                        Text("Only You (\(viewModel.currentComparison.yours.count))")
-                    }
+        ScrollView {
+            VStack(spacing: 16) {
+                VStack(spacing: 16) {
+                    Text("😕")
+                        .font(.system(size: 48))
+                    Text("Something went wrong")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(.white)
+                    Text(message)
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color.white.opacity(0.65))
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-                
-                // Section 2: Shared
-                if !viewModel.currentComparison.shared.isEmpty {
-                    Section {
-                        ForEach(viewModel.sharedCountries, id: \.id) { country in
-                            CountryRow(country: country, badge: .shared)
-                        }
-                    } header: {
-                        Text("Both (\(viewModel.currentComparison.shared.count))")
-                    }
-                }
-                
-                // Section 3: Theirs
-                if !viewModel.currentComparison.theirs.isEmpty {
-                    Section {
-                        ForEach(viewModel.theirCountries, id: \.id) { country in
-                            CountryRow(country: country, badge: .theirs)
-                        }
-                    } header: {
-                        Text("Only Them (\(viewModel.currentComparison.theirs.count))")
-                    }
-                }
-                
-                // Empty state
-                if viewModel.currentComparison.totalUnique == 0 {
-                    Section {
-                        VStack(spacing: 12) {
-                            Image(systemName: "map")
-                                .font(.system(size: 48))
-                                .foregroundStyle(.secondary)
-                            Text("No data to compare")
-                                .font(.headline)
-                            Text("Mark some countries as \(viewModel.selectedMode == .visited ? "visited" : "wishlisted") to see the comparison")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .multilineTextAlignment(.center)
-                        }
+                .frame(maxWidth: .infinity)
+                .padding(24)
+                .background(Color(hex: "#1b1b1b"))
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+                .padding(.horizontal, 16)
+                .padding(.top, 20)
+
+                Button { viewModel.resetToIdle() } label: {
+                    Text("Try Again")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
-                        .padding(.vertical, 40)
+                        .frame(height: 52)
+                        .background(Color(hex: "#1b1b1b"))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .padding(.horizontal, 16)
+                .padding(.bottom, 32)
+            }
+        }
+    }
+
+    // MARK: - Results View
+
+    private var resultsView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                if let profile = viewModel.comparedUserProfile {
+                    heroResultsCard(profile: profile)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 20)
+                }
+
+                let wishlistShared = viewModel.wishlistComparison.shared.count
+                if wishlistShared > 0 {
+                    planTripCard(matchCount: wishlistShared)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 16)
+                }
+
+                // Mode chips
+                HStack(spacing: 8) {
+                    modeChip("Visited", mode: .visited)
+                    modeChip("Wishlist", mode: .wishlist)
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 20)
+
+                if viewModel.currentComparison.totalUnique == 0 {
+                    Text("No \(viewModel.selectedMode == .visited ? "visited" : "wishlisted") countries to compare")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 32)
+                        .padding(.horizontal, 32)
+                        .multilineTextAlignment(.center)
+                } else {
+                    if !viewModel.sharedCountries.isEmpty {
+                        countrySection(label: "BOTH", countries: viewModel.sharedCountries, badge: .shared)
+                            .padding(.top, 20)
+                    }
+                    if !viewModel.yourCountries.isEmpty {
+                        countrySection(label: "ONLY YOU", countries: viewModel.yourCountries, badge: .yours)
+                            .padding(.top, 20)
+                    }
+                    if !viewModel.theirCountries.isEmpty {
+                        let friendName = viewModel.comparedUserProfile.map { friendShortName(from: $0) } ?? "THEM"
+                        countrySection(
+                            label: "ONLY \(friendName.uppercased())",
+                            countries: viewModel.theirCountries,
+                            badge: .theirs
+                        )
+                        .padding(.top, 20)
                     }
                 }
+
+                Spacer().frame(height: 32)
             }
-            .listStyle(.insetGrouped)
         }
     }
-    
-    // MARK: - Map View
-    
-    private var mapView: some View {
-        VStack(spacing: 0) {
-            // Stats Summary Card
-            statsCard
-                .padding(.horizontal)
-                .padding(.bottom, 8)
-            
-            // Map Legend
-            mapLegend
-                .padding(.horizontal)
-                .padding(.bottom, 8)
-            
-            // Map
-            ComparisonMapView(
-                comparison: viewModel.currentComparison,
-                zoomLevel: $mapZoomLevel,
-                onCountryTapped: { countryId in
-                    print("Tapped country: \(countryId)")
+
+    private func heroResultsCard(profile: UserProfile) -> some View {
+        let sharedCount = viewModel.visitedComparison.shared.count
+        let yourCount = viewModel.visitedComparison.yours.count
+        let theirCount = viewModel.visitedComparison.theirs.count
+        let friendName = friendShortName(from: profile)
+
+        return VStack(alignment: .leading, spacing: 16) {
+            // Top row: avatars + email pill
+            HStack(alignment: .center) {
+                HStack(spacing: -14) {
+                    // Your avatar: white circle, dark text
+                    Text(myInitials)
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .frame(width: 44, height: 44)
+                        .background(Color.white)
+                        .clipShape(Circle())
+                    // Friend's avatar: blue circle, white text
+                    Text(friendInitials(from: profile))
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 44, height: 44)
+                        .background(Color(hex: "#6C8EFF"))
+                        .clipShape(Circle())
+                        .overlay(Circle().stroke(Color(hex: "#1b1b1b"), lineWidth: 2))
                 }
-            )
-            .edgesIgnoringSafeArea(.bottom)
-        }
-    }
-    
-    // MARK: - Stats Card
-    
-    private var statsCard: some View {
-        VStack(spacing: 8) {
-            HStack(spacing: 20) {
-                StatItem(
-                    title: "Overlap",
-                    value: "\(Int(viewModel.currentComparison.overlapPercentage))%",
-                    color: .blue
-                )
-                
-                Divider()
-                    .frame(height: 30)
-                
-                StatItem(
-                    title: "Total Unique",
-                    value: "\(viewModel.currentComparison.totalUnique)",
-                    color: .purple
-                )
-                
-                Divider()
-                    .frame(height: 30)
-                
-                StatItem(
-                    title: "Shared",
-                    value: "\(viewModel.currentComparison.shared.count)",
-                    color: .green
-                )
+
+                Spacer()
+
+                // Email pill
+                Text(profile.email)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.white.opacity(0.85))
+                    .lineLimit(1)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(Color.white.opacity(0.12))
+                    .clipShape(Capsule())
             }
-            .padding()
-        }
-        .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-    }
-    
-    // MARK: - Map Legend
-    
-    private var mapLegend: some View {
-        HStack(spacing: 16) {
-            LegendItem(color: .green, label: "Both", count: viewModel.currentComparison.shared.count)
-            LegendItem(color: .blue, label: "You", count: viewModel.currentComparison.yours.count)
-            LegendItem(color: .orange, label: "Them", count: viewModel.currentComparison.theirs.count)
-        }
-        .padding(.vertical, 8)
-        .padding(.horizontal, 12)
-        .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-    }
-}
 
-// MARK: - Supporting Views
+            // "YOU & JOHN" label + big title
+            VStack(alignment: .leading, spacing: 6) {
+                Text("YOU & \(friendName.uppercased())")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.5))
+                    .tracking(0.5)
 
-private struct StatItem: View {
-    let title: String
-    let value: String
-    let color: Color
-    
-    var body: some View {
+                Text("\(sharedCount) countries in common")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundStyle(.white)
+                    .tracking(-0.3)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            // Divider
+            Rectangle()
+                .fill(Color.white.opacity(0.15))
+                .frame(height: 1)
+
+            // Stats row
+            HStack(spacing: 0) {
+                statColumn(value: "\(sharedCount)", label: "Together")
+                Rectangle().fill(Color.white.opacity(0.15)).frame(width: 1, height: 44)
+                statColumn(value: "\(yourCount)", label: "Only you")
+                Rectangle().fill(Color.white.opacity(0.15)).frame(width: 1, height: 44)
+                statColumn(value: "\(theirCount)", label: "Only \(friendName)")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(Color(hex: "#111111"))
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+    }
+
+    private func statColumn(value: String, label: String) -> some View {
         VStack(spacing: 4) {
             Text(value)
-                .font(.title2)
-                .fontWeight(.bold)
-                .foregroundStyle(color)
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity)
-    }
-}
-
-private struct LegendItem: View {
-    let color: Color
-    let label: String
-    let count: Int
-    
-    var body: some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(color)
-                .frame(width: 12, height: 12)
+                .font(.system(size: 26, weight: .bold))
+                .foregroundStyle(.white)
             Text(label)
-                .font(.caption)
-            Text("(\(count))")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+                .font(.system(size: 12))
+                .foregroundStyle(Color.white.opacity(0.5))
         }
+        .frame(maxWidth: .infinity, alignment: .center)
     }
-}
 
-private struct CountryRow: View {
-    let country: Country
-    let badge: ComparisonBadge
-    
-    var body: some View {
-        HStack(spacing: 12) {
-            Text(country.flagEmoji)
-                .font(.title2)
-            
-            VStack(alignment: .leading, spacing: 2) {
-                Text(country.name)
-                    .font(.body)
-                Text(country.continent.displayName)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+    private func planTripCard(matchCount: Int) -> some View {
+        HStack(spacing: 14) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color(hex: "#F3F3F3"))
+                    .frame(width: 44, height: 44)
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 18))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
             }
-            
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Plan a trip together")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                Text("\(matchCount) wishlist \(matchCount == 1 ? "match" : "matches")")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+            }
             Spacer()
-            
-            badge.icon
-                .font(.caption)
-                .foregroundStyle(badge.color)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(badge.color.opacity(0.15))
-                .clipShape(Capsule())
+            Button {
+                viewModel.selectedMode = .wishlist
+            } label: {
+                Text("Plan")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 9)
+                    .background(Color(hex: "#1b1b1b"))
+                    .clipShape(Capsule())
+            }
         }
-        .padding(.vertical, 2)
+        .padding(14)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+    }
+
+    private func modeChip(_ title: String, mode: ComparisonMode) -> some View {
+        Button { viewModel.selectedMode = mode } label: {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(viewModel.selectedMode == mode ? .white : Color(hex: "#6B6B6B"))
+                .padding(.horizontal, 18)
+                .padding(.vertical, 8)
+                .background(viewModel.selectedMode == mode ? Color(hex: "#1b1b1b") : Color.white)
+                .clipShape(Capsule())
+                .overlay(Capsule().stroke(viewModel.selectedMode == mode ? Color.clear : Color(hex: "#E2E2E2"), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func countrySection(label: String, countries: [Country], badge: ComparisonBadge) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color(hex: "#9E9E9E"))
+                .tracking(0.8)
+                .padding(.horizontal, 16)
+
+            VStack(spacing: 8) {
+                ForEach(countries) { country in
+                    NavigationLink {
+                        CountryDetailScreen(country: country)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Text(country.flagEmoji)
+                                .font(.system(size: 28))
+                                .frame(width: 40, height: 36)
+                            Text(country.name)
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                            Spacer()
+                            Text(badge.label)
+                                .font(.system(size: 10, weight: .bold))
+                                .foregroundStyle(badge.pillForeground)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(badge.pillBackground)
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(Color(hex: "#CCCCCC"))
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 14)
+                        .background(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .shadow(color: .black.opacity(0.03), radius: 4, x: 0, y: 1)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func avatarCircle(initials: String, bg: Color) -> some View {
+        Text(initials)
+            .font(.system(size: 13, weight: .bold))
+            .foregroundStyle(.white)
+            .frame(width: 38, height: 38)
+            .background(bg)
+            .clipShape(Circle())
+            .overlay(Circle().stroke(Color(hex: "#1b1b1b"), lineWidth: 2))
+    }
+
+    private var myInitials: String {
+        if let name = authService.user?.displayName, !name.trimmingCharacters(in: .whitespaces).isEmpty {
+            let parts = name.components(separatedBy: " ").filter { !$0.isEmpty }
+            if parts.count >= 2 {
+                return (parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+            }
+            return String(parts[0].prefix(2)).uppercased()
+        }
+        guard let email = authService.user?.email else { return "ME" }
+        return emailInitials(email)
+    }
+
+    private func friendInitials(from profile: UserProfile) -> String {
+        if !profile.firstName.isEmpty {
+            let f = String(profile.firstName.prefix(1)).uppercased()
+            let l = String(profile.lastName.prefix(1)).uppercased()
+            return l.isEmpty ? f : f + l
+        }
+        return emailInitials(profile.email)
+    }
+
+    private func emailInitials(_ email: String) -> String {
+        let username = String(email.split(separator: "@").first ?? "?")
+        let parts = username.split(separator: ".")
+        if parts.count >= 2 {
+            return (String(parts[0].prefix(1)) + String(parts[1].prefix(1))).uppercased()
+        }
+        return String(username.prefix(2)).uppercased()
+    }
+
+    private func friendShortName(from profile: UserProfile) -> String {
+        if !profile.firstName.isEmpty {
+            return String(profile.firstName.prefix(10))
+        }
+        let username = String(profile.email.split(separator: "@").first ?? Substring(profile.email))
+        let first = String(username.split(separator: ".").first ?? Substring(username))
+        return first.prefix(10).capitalized
     }
 }
 
-// MARK: - Badge Type
+// MARK: - Comparison Badge
 
 enum ComparisonBadge {
     case yours
     case shared
     case theirs
-    
-    var icon: some View {
+
+    var label: String {
         switch self {
-        case .yours:
-            return Image(systemName: "person.fill")
-        case .shared:
-            return Image(systemName: "person.2.fill")
-        case .theirs:
-            return Image(systemName: "person.fill")
+        case .yours:   return "Only You"
+        case .shared:  return "Both"
+        case .theirs:  return "Only Them"
         }
     }
-    
-    var color: Color {
+
+    var pillForeground: Color {
         switch self {
-        case .yours:
-            return .blue
-        case .shared:
-            return .green
-        case .theirs:
-            return .orange
+        case .yours:   return Color(hex: "#1E7F4E")
+        case .shared:  return Color(hex: "#1b1b1b")
+        case .theirs:  return Color(hex: "#9E4E00")
+        }
+    }
+
+    var pillBackground: Color {
+        switch self {
+        case .yours:   return Color(hex: "#1E7F4E").opacity(0.1)
+        case .shared:  return Color(hex: "#1b1b1b").opacity(0.08)
+        case .theirs:  return Color(hex: "#F37826").opacity(0.15)
         }
     }
 }
@@ -504,273 +535,138 @@ enum ComparisonBadge {
 @MainActor
 final class ComparisonViewModel: ObservableObject {
     // MARK: - State Management
-    
+
     enum ViewState: Equatable {
-        case idle                    // Initial state - show search UI
-        case loading                 // Fetching user data
-        case loaded                  // Comparison data loaded successfully
-        case error(String)          // Error occurred
+        case idle
+        case loading
+        case loaded
+        case error(String)
     }
-    
+
     @Published var state: ViewState = .idle
     @Published var selectedMode: ComparisonMode = .visited
     @Published var emailToCompare: String = ""
     @Published private(set) var comparedUserProfile: UserProfile?
-    
-    // Comparison results (only populated in .loaded state)
+
     @Published private(set) var visitedComparison: TravelComparisonResult
     @Published private(set) var wishlistComparison: TravelComparisonResult
-    
-    // Services and data
+
     private let countryService = CountryDataService.shared
     private let profileRepository = FirestoreUserRepository()
     private let visitRepository = FirestoreVisitRepository()
     private var allCountries: [Country] = []
-    
-    // Current comparison based on selected mode
+
     var currentComparison: TravelComparisonResult {
         selectedMode == .visited ? visitedComparison : wishlistComparison
     }
-    
-    // Convert country IDs to Country objects
-    var yourCountries: [Country] {
-        getCountries(for: Array(currentComparison.yours))
-    }
-    
-    var sharedCountries: [Country] {
-        getCountries(for: Array(currentComparison.shared))
-    }
-    
-    var theirCountries: [Country] {
-        getCountries(for: Array(currentComparison.theirs))
-    }
-    
+
+    var yourCountries: [Country] { getCountries(for: Array(currentComparison.yours)) }
+    var sharedCountries: [Country] { getCountries(for: Array(currentComparison.shared)) }
+    var theirCountries: [Country] { getCountries(for: Array(currentComparison.theirs)) }
+
     init() {
-        // Initialize with empty comparisons
-        self.visitedComparison = TravelComparisonResult(
-            yours: [],
-            shared: [],
-            theirs: [],
-            mode: .visited
-        )
-        self.wishlistComparison = TravelComparisonResult(
-            yours: [],
-            shared: [],
-            theirs: [],
-            mode: .wishlist
-        )
-        
-        // Load countries
+        self.visitedComparison = TravelComparisonResult(yours: [], shared: [], theirs: [], mode: .visited)
+        self.wishlistComparison = TravelComparisonResult(yours: [], shared: [], theirs: [], mode: .wishlist)
         self.allCountries = countryService.loadCountries()
     }
-    
+
     // MARK: - Public Methods
-    
-    /// Search for a user by email and load their comparison data
+
     func searchUser(yourVisits: [String: Visit]) async {
         state = .loading
-        
-        // Create a timeout task (8 seconds like in AccountScreen)
+
         let timeoutTask = Task {
-            try? await Task.sleep(nanoseconds: 8_000_000_000) // 8 seconds
+            try? await Task.sleep(nanoseconds: 8_000_000_000)
             if case .loading = state {
                 state = .error("Request timed out. Please check your internet connection and try again.")
-                
-                #if DEBUG
-                print("⏱️ Search operation timed out after 8 seconds")
-                #endif
             }
         }
-        
-        defer {
-            timeoutTask.cancel()
-        }
-        
+        defer { timeoutTask.cancel() }
+
         do {
-            // Step 1: Find the profile by email
             let profile: UserProfile?
             do {
                 profile = try await profileRepository.findProfileByEmail(emailToCompare)
             } catch {
-                // Cancel timeout before handling error
                 timeoutTask.cancel()
-                
-                // Network error occurred during profile lookup
-                let errorMessage = userFriendlyErrorMessage(from: error)
-                state = .error(errorMessage)
-                
-                #if DEBUG
-                print("❌ Network error during profile lookup: \(error)")
-                #endif
+                state = .error(userFriendlyErrorMessage(from: error))
                 return
             }
-            
-            // Check if profile was found
+
             guard let profile else {
                 timeoutTask.cancel()
                 state = .error("User not found or they have disabled comparison in their privacy settings")
                 return
             }
-            
-            #if DEBUG
-            print("✅ Found user profile: \(profile.email)")
-            #endif
-            
-            // Step 2: Fetch their visits
+
             let theirVisitsArray = try await visitRepository.allVisits(forUserId: profile.id)
-            
-            #if DEBUG
-            print("✅ Fetched \(theirVisitsArray.count) visits for user \(profile.email)")
-            #endif
-            
-            // Step 3: Convert to dictionary for comparison engine
             let theirVisitsDict = Dictionary(uniqueKeysWithValues: theirVisitsArray.map { ($0.countryId, $0) })
-            
-            // Step 4: Perform comparisons
-            visitedComparison = TravelComparisonEngine.compare(
-                yourVisits: yourVisits,
-                theirVisits: theirVisitsDict,
-                mode: .visited
-            )
-            
-            wishlistComparison = TravelComparisonEngine.compare(
-                yourVisits: yourVisits,
-                theirVisits: theirVisitsDict,
-                mode: .wishlist
-            )
-            
-            // Step 5: Update state
+
+            visitedComparison = TravelComparisonEngine.compare(yourVisits: yourVisits, theirVisits: theirVisitsDict, mode: .visited)
+            wishlistComparison = TravelComparisonEngine.compare(yourVisits: yourVisits, theirVisits: theirVisitsDict, mode: .wishlist)
+
             comparedUserProfile = profile
             state = .loaded
-            
-            // Cancel timeout on success
             timeoutTask.cancel()
-            
         } catch {
-            // Cancel timeout before handling error
             timeoutTask.cancel()
-            
-            // Detect and handle network errors specifically
-            let errorMessage = userFriendlyErrorMessage(from: error)
-            state = .error(errorMessage)
-            
-            #if DEBUG
-            print("❌ Failed to fetch visits: \(error)")
-            #endif
+            state = .error(userFriendlyErrorMessage(from: error))
         }
     }
-    
-    /// Reload the comparison with updated visit data (called when user's visits change)
+
     func reloadComparison(yourVisits: [String: Visit]) {
         guard case .loaded = state, let profile = comparedUserProfile else { return }
-        
-        // Re-fetch the other user's visits and re-compare
         Task {
             do {
                 let theirVisitsArray = try await visitRepository.allVisits(forUserId: profile.id)
                 let theirVisitsDict = Dictionary(uniqueKeysWithValues: theirVisitsArray.map { ($0.countryId, $0) })
-                
-                // Perform comparisons
-                visitedComparison = TravelComparisonEngine.compare(
-                    yourVisits: yourVisits,
-                    theirVisits: theirVisitsDict,
-                    mode: .visited
-                )
-                
-                wishlistComparison = TravelComparisonEngine.compare(
-                    yourVisits: yourVisits,
-                    theirVisits: theirVisitsDict,
-                    mode: .wishlist
-                )
-                
-                #if DEBUG
-                print("✅ Reloaded comparison with updated data")
-                #endif
-                
+                visitedComparison = TravelComparisonEngine.compare(yourVisits: yourVisits, theirVisits: theirVisitsDict, mode: .visited)
+                wishlistComparison = TravelComparisonEngine.compare(yourVisits: yourVisits, theirVisits: theirVisitsDict, mode: .wishlist)
             } catch {
                 #if DEBUG
                 print("⚠️ Failed to reload comparison: \(error)")
                 #endif
-                // Don't change state - keep showing old data
             }
         }
     }
-    
-    /// Reset to idle state (ready to search for a new user)
+
     func resetToIdle() {
         state = .idle
         emailToCompare = ""
         comparedUserProfile = nil
-        
-        // Clear comparison data
-        visitedComparison = TravelComparisonResult(
-            yours: [],
-            shared: [],
-            theirs: [],
-            mode: .visited
-        )
-        wishlistComparison = TravelComparisonResult(
-            yours: [],
-            shared: [],
-            theirs: [],
-            mode: .wishlist
-        )
+        visitedComparison = TravelComparisonResult(yours: [], shared: [], theirs: [], mode: .visited)
+        wishlistComparison = TravelComparisonResult(yours: [], shared: [], theirs: [], mode: .wishlist)
     }
-    
+
     // MARK: - Error Handling
-    
-    /// Convert errors into user-friendly messages, detecting network issues
+
     private func userFriendlyErrorMessage(from error: Error) -> String {
         let nsError = error as NSError
-        
-        // Check for network-related error codes
-        // NSURLErrorDomain codes: https://developer.apple.com/documentation/foundation/nsurlerrordomain
         if nsError.domain == NSURLErrorDomain {
             switch nsError.code {
-            case NSURLErrorNotConnectedToInternet:
-                return "No internet connection. Please check your network and try again."
-            case NSURLErrorNetworkConnectionLost:
-                return "Network connection was lost. Please try again."
+            case NSURLErrorNotConnectedToInternet:  return "No internet connection. Please check your network and try again."
+            case NSURLErrorNetworkConnectionLost:   return "Network connection was lost. Please try again."
             case NSURLErrorCannotConnectToHost, NSURLErrorCannotFindHost:
                 return "Unable to connect to server. Please check your internet connection."
-            case NSURLErrorTimedOut:
-                return "Connection timed out. Please try again."
-            case NSURLErrorDNSLookupFailed:
-                return "Network error: DNS lookup failed. Please check your connection."
-            default:
-                return "Network error. Please check your connection and try again."
+            case NSURLErrorTimedOut:                return "Connection timed out. Please try again."
+            default:                                return "Network error. Please check your connection and try again."
             }
         }
-        
-        // Check for Firebase-specific network errors
-        // Firebase Firestore error domain
         if nsError.domain == "FIRFirestoreErrorDomain" {
             switch nsError.code {
-            case 14: // UNAVAILABLE - network issue or server unavailable
-                return "Unable to connect to the server. Please check your internet connection and try again."
-            case 4: // DEADLINE_EXCEEDED - operation timeout
-                return "Request timed out. Please check your connection and try again."
-            case 7: // PERMISSION_DENIED
-                return "Permission denied. The user may have changed their privacy settings."
-            default:
-                break
+            case 14: return "Unable to connect to the server. Please check your internet connection and try again."
+            case 4:  return "Request timed out. Please check your connection and try again."
+            case 7:  return "Permission denied. The user may have changed their privacy settings."
+            default: break
             }
         }
-        
-        // Default error message with original description
         return "Failed to load user: \(error.localizedDescription)"
     }
-    
+
     // MARK: - Helpers
-    
+
     private func getCountries(for countryIds: [String]) -> [Country] {
         let countryDict = Dictionary(uniqueKeysWithValues: allCountries.map { ($0.id, $0) })
         return countryIds.compactMap { countryDict[$0] }.sorted { $0.name < $1.name }
     }
-}
-
-// MARK: - Preview
-
-#Preview {
-    ComparisonView()
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/DeleteAccountView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/DeleteAccountView.swift
@@ -10,181 +10,273 @@ import SwiftUI
 struct DeleteAccountView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var authService: AuthService
-    
+
     @State private var password = ""
     @State private var confirmationText = ""
     @State private var errorMessage: String?
     @State private var isDeleting = false
-    
+    @State private var showPassword = false
+
     // MARK: - Validation
-    
-    /// Check if the form is valid and ready for submission
-    /// Requires both password and exact "DELETE" confirmation
+
     private var isFormValid: Bool {
         !password.isEmpty &&
         confirmationText == "DELETE" &&
         !isDeleting
     }
-    
+
+    private var confirmationValid: Bool { confirmationText == "DELETE" }
+
     // MARK: - Body
-    
+
     var body: some View {
-        NavigationStack {
-            Form {
-                // MARK: - Warning Section
-                Section {
-                    VStack(alignment: .leading, spacing: 12) {
-                        HStack(spacing: 8) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(.red)
-                            Text("This Action is Permanent")
-                                .font(.headline)
-                                .foregroundStyle(.red)
-                        }
-                        
-                        Text("Deleting your account will:")
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                        
-                        VStack(alignment: .leading, spacing: 6) {
-                            Label("Remove all your travel data", systemImage: "xmark.circle")
-                            Label("Delete your account permanently", systemImage: "xmark.circle")
-                            Label("Cannot be recovered or undone", systemImage: "xmark.circle")
-                        }
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    }
-                    .padding(.vertical, 8)
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Delete Account")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                Spacer()
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 26))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
                 }
-                
-                // MARK: - Password Section
-                Section {
-                    SecureField("Password", text: $password)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                } header: {
-                    Text("Verify Identity")
-                } footer: {
-                    Text("Enter your password to continue")
-                }
-                
-                // MARK: - Confirmation Section
-                Section {
-                    TextField("Type DELETE to confirm", text: $confirmationText)
-                        .autocorrectionDisabled()
-                } header: {
-                    Text("Type DELETE to Confirm")
-                } footer: {
-                    if confirmationText.isEmpty {
-                        Text("Type exactly: DELETE")
-                    } else if confirmationText != "DELETE" {
-                        Text("Must match exactly: DELETE")
-                            .foregroundStyle(.orange)
-                    } else {
-                        Text("Confirmation accepted")
-                            .foregroundStyle(.green)
-                    }
-                }
-                
-                // MARK: - Delete Button Section
-                Section {
-                    Button(role: .destructive) {
-                        Task {
-                            await deleteAccount()
-                        }
-                    } label: {
-                        HStack {
-                            if isDeleting {
-                                ProgressView()
-                                    .padding(.trailing, 8)
-                            }
-                            Text(isDeleting ? "Deleting Account..." : "Delete My Account")
-                        }
-                        .frame(maxWidth: .infinity)
-                    }
-                    .disabled(!isFormValid)
-                }
-                
-                // MARK: - Error Section
-                if let errorMessage {
-                    Section {
-                        Text(errorMessage)
-                            .foregroundStyle(.red)
-                    } header: {
-                        Text("Error")
-                    }
-                }
+                .buttonStyle(.plain)
+                .disabled(isDeleting)
             }
-            .navigationTitle("Delete Account")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        dismiss()
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 20)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+
+                    // MARK: Warning
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("THIS ACTION IS PERMANENT")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .tracking(0.8)
+                            .padding(.horizontal, 4)
+
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text("Deleting your account will:")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                                .padding(.horizontal, 16)
+                                .padding(.top, 16)
+                                .padding(.bottom, 12)
+
+                            Divider().padding(.horizontal, 16)
+
+                            warningRow(
+                                icon: "xmark.circle.fill",
+                                iconColor: Color(hex: "#F9234D"),
+                                iconBg: Color(hex: "#FFF0F5"),
+                                text: "Remove all your travel data"
+                            )
+
+                            Divider().padding(.horizontal, 16)
+
+                            warningRow(
+                                icon: "trash.fill",
+                                iconColor: Color(hex: "#F9234D"),
+                                iconBg: Color(hex: "#FFF0F5"),
+                                text: "Delete your account permanently"
+                            )
+
+                            Divider().padding(.horizontal, 16)
+
+                            warningRow(
+                                icon: "exclamationmark.triangle.fill",
+                                iconColor: Color(hex: "#E6A817"),
+                                iconBg: Color(hex: "#FFF9E6"),
+                                text: "Cannot be recovered or undone"
+                            )
+
+                            Spacer(minLength: 4)
+                        }
+                        .background(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
                     }
-                    .disabled(isDeleting)
+
+                    // MARK: Verify identity
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("VERIFY IDENTITY")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .tracking(0.8)
+                            .padding(.horizontal, 4)
+
+                        HStack(spacing: 12) {
+                            Group {
+                                if showPassword {
+                                    TextField("Password", text: $password)
+                                } else {
+                                    SecureField("Password", text: $password)
+                                }
+                            }
+                            .font(.system(size: 15))
+                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+
+                            Button {
+                                showPassword.toggle()
+                            } label: {
+                                Image(systemName: showPassword ? "eye.fill" : "eye.slash.fill")
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(showPassword ? Color(hex: "#6B6B6B") : Color(hex: "#CCCCCC"))
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 16)
+                        .background(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+
+                        Text("Enter your password to continue")
+                            .font(.system(size: 12))
+                            .foregroundStyle(Color(hex: "#BBBBBB"))
+                            .padding(.horizontal, 4)
+                    }
+
+                    // MARK: Confirm deletion
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("CONFIRM DELETION")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .tracking(0.8)
+                            .padding(.horizontal, 4)
+
+                        VStack(spacing: 0) {
+                            TextField("Type DELETE to confirm", text: $confirmationText)
+                                .font(.system(size: 15))
+                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                                .autocorrectionDisabled()
+                                .textInputAutocapitalization(.characters)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 16)
+
+                            Divider().padding(.horizontal, 16)
+
+                            HStack(spacing: 8) {
+                                Image(systemName: confirmationValid ? "checkmark.circle.fill" : "info.circle.fill")
+                                    .font(.system(size: 15))
+                                    .foregroundStyle(confirmationValid ? Color(hex: "#2E9E5B") : Color(hex: "#CCCCCC"))
+                                Text(confirmationValid ? "Confirmed" : "Type exactly: DELETE")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(confirmationValid ? Color(hex: "#2E9E5B") : Color(hex: "#9E9E9E"))
+                                Spacer()
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 14)
+                        }
+                        .background(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+                    }
+
+                    // MARK: Error
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.system(size: 13))
+                            .foregroundStyle(.red)
+                            .padding(.horizontal, 4)
+                    }
+
+                    // MARK: Actions
+                    VStack(spacing: 14) {
+                        Button {
+                            Task { await deleteAccount() }
+                        } label: {
+                            HStack(spacing: 8) {
+                                if isDeleting {
+                                    ProgressView()
+                                        .tint(.white)
+                                }
+                                Text(isDeleting ? "Deleting Account..." : "Delete My Account")
+                                    .font(.system(size: 16, weight: .bold))
+                                    .foregroundStyle(.white)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 18)
+                            .background(isFormValid ? Color(hex: "#F9234D") : Color(hex: "#CCCCCC"))
+                            .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(!isFormValid)
+
+                        Button { dismiss() } label: {
+                            Text("Cancel")
+                                .font(.system(size: 15))
+                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(isDeleting)
+                    }
                 }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 32)
             }
         }
+        .background(Color(hex: "#F7F7F7"))
     }
-    
+
+    // MARK: - Warning Row
+
+    private func warningRow(icon: String, iconColor: Color, iconBg: Color, text: String) -> some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle().fill(iconBg).frame(width: 36, height: 36)
+                Image(systemName: icon)
+                    .font(.system(size: 15))
+                    .foregroundStyle(iconColor)
+            }
+            Text(text)
+                .font(.system(size: 14))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+
     // MARK: - Deletion Logic
-    
-    /// Execute the account deletion workflow
-    /// 1. Reauthenticate with password
-    /// 2. Delete Firestore data
-    /// 3. Delete Firebase Auth account
-    /// 4. Dismiss sheet after successful deletion
+
     private func deleteAccount() async {
-        // Clear previous error
         errorMessage = nil
         isDeleting = true
-        
-        defer {
-            isDeleting = false
-        }
-        
+        defer { isDeleting = false }
+
         do {
             try await authService.deleteAccount(currentPassword: password)
-            
-            // Dismiss the sheet immediately after successful deletion
-            // The auth state listener will handle sign-out and data cleanup in the background
             dismiss()
-            
         } catch let error as NSError {
-            // Map Firebase errors to user-friendly messages
             errorMessage = friendlyErrorMessage(from: error)
         }
     }
-    
+
     // MARK: - Error Handling
-    
-    /// Convert Firebase error codes to user-friendly messages for account deletion
-    /// - Parameter error: The error from Firebase Auth or Firestore
-    /// - Returns: A user-friendly error message
+
     private func friendlyErrorMessage(from error: NSError) -> String {
-        // Firebase Auth errors use domain "FIRAuthErrorDomain"
         if error.domain == "FIRAuthErrorDomain" {
             switch error.code {
-            case 17009: // ERROR_WRONG_PASSWORD
+            case 17009, 17004, 17999:
                 return "Password is incorrect. Please try again"
-            case 17004: // ERROR_INVALID_EMAIL (can mean wrong password in reauthentication)
-                return "Password is incorrect. Please try again"
-            case 17020: // ERROR_NETWORK_REQUEST_FAILED
+            case 17020:
                 return "Network error. Please check your connection and try again"
-            case 17999: // ERROR_INVALID_CREDENTIAL
-                return "Password is incorrect. Please try again"
-            case 17011: // ERROR_USER_NOT_FOUND
+            case 17011:
                 return "User session expired. Please sign in again"
-            case 17014: // ERROR_USER_MISMATCH
+            case 17014:
                 return "Authentication error. Please try again"
-            case 17995: // ERROR_REQUIRES_RECENT_LOGIN
+            case 17995:
                 return "Session expired. Please sign out and sign back in to delete your account"
             default:
-                // For unknown Firebase errors, check the error message
                 let message = error.localizedDescription.lowercased()
-                
-                // Parse common error patterns
                 if message.contains("credential") && (message.contains("malformed") || message.contains("expired")) {
                     return "Password is incorrect. Please try again"
                 } else if message.contains("network") || message.contains("connection") {
@@ -192,16 +284,14 @@ struct DeleteAccountView: View {
                 } else if message.contains("recent") && message.contains("login") {
                     return "Session expired. Please sign out and sign back in to delete your account"
                 } else {
-                    // Generic fallback for account deletion
                     return "Unable to delete account. Please try again or contact support"
                 }
             }
         } else if error.domain == "FIRFirestoreErrorDomain" {
-            // Firestore errors during visit data deletion
             switch error.code {
-            case 7: // Permission denied
+            case 7:
                 return "Permission error. Please try signing out and back in"
-            case 14: // Unavailable (often network/offline)
+            case 14:
                 return "Network error. Please check your connection and try again"
             default:
                 let message = error.localizedDescription.lowercased()
@@ -212,7 +302,6 @@ struct DeleteAccountView: View {
                 }
             }
         } else {
-            // For non-Firebase errors, check for network issues
             let message = error.localizedDescription.lowercased()
             if message.contains("network") || message.contains("internet") || message.contains("connection") {
                 return "Network error. Please check your connection and try again"

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/FirestoreUserRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/FirestoreUserRepository.swift
@@ -68,6 +68,8 @@ final class FirestoreUserRepository {
         
         let data: [String: Any] = [
             "email": normalizedEmail,
+            "firstName": profile.firstName,
+            "lastName": profile.lastName,
             "allowComparison": profile.allowComparison,
             "createdAt": Timestamp(date: profile.createdAt),
             "updatedAt": Timestamp(date: Date())
@@ -134,7 +136,9 @@ final class FirestoreUserRepository {
         guard let email = data["email"] as? String else {
             throw FirestoreUserRepositoryError.invalidProfileData
         }
-        
+
+        let firstName = data["firstName"] as? String ?? ""
+        let lastName = data["lastName"] as? String ?? ""
         let allowComparison = data["allowComparison"] as? Bool ?? false
         
         let createdAt: Date
@@ -154,6 +158,8 @@ final class FirestoreUserRepository {
         return UserProfile(
             userId: userId,
             email: email,
+            firstName: firstName,
+            lastName: lastName,
             allowComparison: allowComparison,
             createdAt: createdAt,
             updatedAt: updatedAt

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
@@ -211,48 +211,19 @@ final class SyncService {
     }
 
     private func pushToCloud(_ visit: Visit) async throws {
-        // Use setVisited for the main data, including wantToVisit
-        try await cloudRepository.setVisited(
-            visit.countryId,
-            isVisited: visit.isVisited,
-            visitedDate: visit.visitedDate,
-            notes: visit.notes,
-            wantToVisit: visit.wantToVisit  // Pass the local value
-        )
-        
-        // Sync photos separately - don't fail the entire sync if photos fail
-        let cloudVisit = try? await cloudRepository.visit(for: visit.countryId)
-        let cloudPhotos = cloudVisit?.photos ?? []
-        
-        // Add any new photos that aren't in the cloud
-        for photo in visit.photos {
-            if !cloudPhotos.contains(where: { $0.id == photo.id }) {
-                try? await cloudRepository.addPhoto(visit.countryId, photo: photo)
-            }
-        }
-        
-        // Remove photos that were deleted locally
-        for cloudPhoto in cloudPhotos {
-            if !visit.photos.contains(where: { $0.id == cloudPhoto.id }) {
-                try? await cloudRepository.removePhoto(visit.countryId, photoId: cloudPhoto.id)
-            }
-        }
+        // Write all visit fields including photos in a single atomic Firestore write.
+        // The old approach called setVisited (which wiped the photos field) then added
+        // photos one-by-one with try?, causing photo loss on any network hiccup.
+        try await cloudRepository.setVisit(visit)
     }
 
     private func saveToLocal(_ visit: Visit) throws {
+        // Photos are local-only (not synced to Firestore), so always preserve whatever
+        // photos are already stored on this device.
+        var mergedVisit = visit
         let existingVisit = try? localRepository.visit(for: visit.countryId)
-        
-        if let existingVisit = existingVisit {
-            // Entity exists - preserve local photos if cloud has none, otherwise use cloud photos
-            var mergedVisit = visit
-            if visit.photos.isEmpty && !existingVisit.photos.isEmpty {
-                mergedVisit.photos = existingVisit.photos
-            }
-            try localRepository.upsert(mergedVisit)
-        } else {
-            // New visit - just save it (including cloud photos if any)
-            try localRepository.upsert(visit)
-        }
+        mergedVisit.photos = existingVisit?.photos ?? []
+        try localRepository.upsert(mergedVisit)
     }
 }
 

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/UserProfile.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/UserProfile.swift
@@ -7,40 +7,56 @@
 
 import Foundation
 
-/// Represents a user's public profile for travel comparison
-/// Stored at: users/{userId}/profile
 struct UserProfile: Codable, Identifiable, Equatable {
-    /// Firebase Auth user ID
     let id: String
-    
-    /// User's email address (for lookup)
     let email: String
-    
-    /// Privacy control: whether this user's travel data can be compared by others
-    /// Default: false (private)
+    var firstName: String
+    var lastName: String
     var allowComparison: Bool
-    
-    /// When this profile was created
     let createdAt: Date
-    
-    /// When the profile was last updated
     var updatedAt: Date
-    
-    init(userId: String, email: String, allowComparison: Bool = false) {
+
+    var displayName: String {
+        let name = "\(firstName) \(lastName)".trimmingCharacters(in: .whitespaces)
+        return name.isEmpty ? email : name
+    }
+
+    var initials: String {
+        let f = String(firstName.prefix(1)).uppercased()
+        let l = String(lastName.prefix(1)).uppercased()
+        if !f.isEmpty && !l.isEmpty { return f + l }
+        if !f.isEmpty { return f }
+        return emailInitials(email)
+    }
+
+    init(userId: String, email: String, firstName: String = "", lastName: String = "", allowComparison: Bool = false) {
         self.id = userId
         self.email = email
+        self.firstName = firstName
+        self.lastName = lastName
         self.allowComparison = allowComparison
         let now = Date()
         self.createdAt = now
         self.updatedAt = now
     }
-    
-    /// Internal initializer for recreating profiles from Firestore with all fields
-    init(userId: String, email: String, allowComparison: Bool, createdAt: Date, updatedAt: Date) {
+
+    init(userId: String, email: String, firstName: String, lastName: String, allowComparison: Bool, createdAt: Date, updatedAt: Date) {
         self.id = userId
         self.email = email
+        self.firstName = firstName
+        self.lastName = lastName
         self.allowComparison = allowComparison
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+    }
+
+    private func emailInitials(_ email: String) -> String {
+        let parts = email.components(separatedBy: "@").first?
+            .components(separatedBy: CharacterSet(charactersIn: "._-"))
+            .filter { !$0.isEmpty } ?? []
+        if parts.count >= 2 {
+            return (parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+        }
+        return String((parts.first ?? "?").prefix(1)).uppercased()
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
@@ -16,46 +16,30 @@ struct AccountScreen: View {
     @State private var countries: [Country] = []
     @State private var showingChangePassword = false
     @State private var showingDeleteAccount = false
-    
-    // MARK: - Profile Privacy State
-    
+
+    // MARK: - Privacy State
+
     @State private var userProfile: UserProfile?
     @State private var isLoadingProfile = true
     @State private var allowComparison = false
     @State private var isSavingComparison = false
     @State private var pendingComparisonValue: Bool?
-    
-    // MARK: - Email Lookup Testing
-    
-    @State private var testEmail = ""
-    @State private var lookupResult: String?
-    @State private var isLookingUp = false
-    
+
     private let profileRepository = FirestoreUserRepository()
-    
-    // MARK: - Computed Properties for Travel Stats
-    
-    /// Number of countries the user has visited
-    private var visitedCount: Int {
-        appState.visitedCountryIDs.count
-    }
-    
-    /// Number of countries on the user's wishlist
-    private var wishlistCount: Int {
-        appState.wantToVisitCountryIDs.count
-    }
-    
-    /// Percentage of the world the user has explored
+
+    // MARK: - Computed Properties
+
+    private var visitedCount: Int { appState.visitedCountryIDs.count }
+    private var wishlistCount: Int { appState.wantToVisitCountryIDs.count }
+
     private var visitedPercentage: Double {
         guard totalCountries > 0 else { return 0 }
         return Double(visitedCount) / Double(totalCountries) * 100
     }
-    
-    /// Number of countries visited this year
+
     private var visitedThisYear: Int {
         let calendar = Calendar.current
         let currentYear = calendar.component(.year, from: Date())
-        
         return appState.visits.values
             .filter { $0.isVisited }
             .filter { visit in
@@ -64,581 +48,404 @@ struct AccountScreen: View {
             }
             .count
     }
-    
-    /// Achievement summary (total and unlocked counts)
+
     private var achievementSummary: (total: Int, unlocked: Int) {
         guard !countries.isEmpty else { return (0, 0) }
-        
-        let achievements = AchievementEngine.calculateAchievements(
-            visits: appState.visits,
-            countries: countries
-        )
+        let achievements = AchievementEngine.calculateAchievements(visits: appState.visits, countries: countries)
         return AchievementEngine.achievementSummary(achievements)
     }
-    
-    // MARK: - Helper Functions for Profile Avatar
-    
-    /// Extract initials from email address
-    /// - Parameter email: User's email address
-    /// - Returns: 1-2 character initials (e.g., "JD" from "john.doe@example.com")
+
     private func initials(from email: String) -> String {
-        // Get the part before @ symbol
         let components = email.components(separatedBy: "@")
-        guard let namePart = components.first, !namePart.isEmpty else {
-            return "?" // Fallback for invalid email
-        }
-        
-        // Split by common separators (., _, -)
-        let nameComponents = namePart.components(separatedBy: CharacterSet(charactersIn: "._-"))
-            .filter { !$0.isEmpty }
-        
+        guard let namePart = components.first, !namePart.isEmpty else { return "?" }
+        let nameComponents = namePart.components(separatedBy: CharacterSet(charactersIn: "._-")).filter { !$0.isEmpty }
         if nameComponents.count >= 2 {
-            // Two-letter initials from first two components (e.g., "john.doe" → "JD")
-            let first = nameComponents[0].prefix(1).uppercased()
-            let second = nameComponents[1].prefix(1).uppercased()
-            return first + second
-        } else if let first = nameComponents.first {
-            // Single letter from first component (e.g., "john" → "J")
-            return String(first.prefix(1).uppercased())
-        } else {
-            return "?" // Fallback
+            return nameComponents[0].prefix(1).uppercased() + nameComponents[1].prefix(1).uppercased()
+        }
+        return String((nameComponents.first ?? "?").prefix(1).uppercased())
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 0) {
+                    profileSection
+                        .padding(.horizontal, 16)
+                        .padding(.top, 28)
+
+                    overviewCard
+                        .padding(.horizontal, 16)
+                        .padding(.top, 24)
+
+                    highlightsCard
+                        .padding(.horizontal, 16)
+                        .padding(.top, 16)
+
+                    privacyCard
+                        .padding(.horizontal, 16)
+                        .padding(.top, 16)
+
+                    settingsCard
+                        .padding(.horizontal, 16)
+                        .padding(.top, 16)
+
+                    signOutCard
+                        .padding(.horizontal, 16)
+                        .padding(.top, 16)
+
+                    Button {
+                        showingDeleteAccount = true
+                    } label: {
+                        Text("DELETE ACCOUNT")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Color(hex: "#BBBBBB"))
+                            .tracking(1.2)
+                    }
+                    .padding(.top, 16)
+                    .padding(.bottom, 32)
+
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.system(size: 13))
+                            .foregroundStyle(.red)
+                            .padding(.horizontal, 24)
+                            .padding(.bottom, 16)
+                    }
+                }
+            }
+            .background(Color(hex: "#F7F7F7"))
+            .navigationTitle("Account")
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showingChangePassword) { ChangePasswordView() }
+            .sheet(isPresented: $showingDeleteAccount) { DeleteAccountView() }
+            .task {
+                let loaded = CountryDataService.shared.loadCountries()
+                countries = loaded
+                totalCountries = loaded.count
+                await loadProfile()
+            }
         }
     }
-    
-    /// Generate consistent avatar color from email
-    /// - Parameter email: User's email address
-    /// - Returns: Color that will be consistent for the same email across all app launches
-    private func avatarColor(for email: String) -> Color {
-        // Define a palette of pleasant colors for avatars
-        let colors: [Color] = [
-            .blue,
-            .green,
-            .orange,
-            .purple,
-            .pink,
-            .teal,
-            .indigo,
-            .cyan
-        ]
-        
-        // Generate stable hash from email using simple character-based algorithm
-        // This ensures the same email always produces the same color across all sessions
-        var hash = 0
-        for char in email.utf8 {
-            hash = (hash &* 31 &+ Int(char)) & 0x7FFFFFFF
+
+    // MARK: - Profile Section
+
+    private var profileInitials: String {
+        if let profile = userProfile, !profile.firstName.isEmpty {
+            return profile.initials
         }
-        
-        let index = hash % colors.count
-        return colors[index]
+        if let name = authService.user?.displayName, !name.trimmingCharacters(in: .whitespaces).isEmpty {
+            let parts = name.components(separatedBy: " ").filter { !$0.isEmpty }
+            if parts.count >= 2 {
+                return (parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+            }
+            return String(parts[0].prefix(1)).uppercased()
+        }
+        return initials(from: authService.userEmail)
     }
-    
+
+    private var profileSection: some View {
+        VStack(spacing: 14) {
+            ZStack {
+                Circle()
+                    .fill(Color(hex: "#1b1b1b"))
+                    .frame(width: 80, height: 80)
+                Text(profileInitials)
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+
+            VStack(spacing: 4) {
+                Text(authService.displayName)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+
+                if authService.displayName != authService.userEmail {
+                    Text(authService.userEmail)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                }
+            }
+
+            HStack(spacing: 8) {
+                statPill("\(visitedCount) Countries")
+                statPill(String(format: "%.1f%%", visitedPercentage))
+                statPill("\(wishlistCount) Wishlist")
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func statPill(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(Color(hex: "#1b1b1b"))
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(Color.white)
+            .clipShape(Capsule())
+            .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+    }
+
+    // MARK: - Travel Overview Card
+
+    private var overviewCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Travel overview")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+
+            VStack(spacing: 16) {
+                // Visited countries row
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 12) {
+                        iconCircle("scope", bg: Color(hex: "#FFF0F5"), fg: Color(hex: "#F9234D"))
+                        Text("\(visitedCount) Countries Visited")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                        Spacer()
+                        Text(String(format: "%.1f%%", visitedPercentage))
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                    }
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(Color(hex: "#EEEEEE"))
+                                .frame(height: 4)
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(Color(hex: "#F9234D"))
+                                .frame(width: max(geo.size.width * (visitedPercentage / 100), visitedCount > 0 ? 4 : 0), height: 4)
+                        }
+                    }
+                    .frame(height: 4)
+                }
+
+                Divider()
+
+                // Wishlist row
+                HStack(spacing: 12) {
+                    iconCircle("star.fill", bg: Color(hex: "#EAF6FE"), fg: Color(hex: "#4A90D9"))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("\(wishlistCount) on Wishlist")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                        Text("Your next destinations")
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                    }
+                    Spacer()
+                }
+            }
+            .padding(16)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+        }
+    }
+
+    // MARK: - Travel Highlights Card
+
+    private var highlightsCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Travel highlights")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+
+            VStack(spacing: 16) {
+                HStack(spacing: 12) {
+                    iconCircle("calendar", bg: Color(hex: "#F0FFF4"), fg: Color(hex: "#2E9E5B"))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("\(visitedThisYear) Visited This Year")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                        Text(visitedThisYear > 0 ? "Active traveler" : "Start your \(Calendar.current.component(.year, from: Date())) travels")
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                    }
+                    Spacer()
+                }
+
+                Divider()
+
+                HStack(spacing: 12) {
+                    iconCircle("trophy.fill", bg: Color(hex: "#FFF9E6"), fg: Color(hex: "#E6A817"))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("\(achievementSummary.unlocked)/\(achievementSummary.total) Achievements")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                        Text(achievementSummary.unlocked > 0 ? "Nomad status" : "Unlock your first achievement")
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                    }
+                    Spacer()
+                }
+            }
+            .padding(16)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+        }
+    }
+
+    // MARK: - Privacy Card
+
+    private var privacyCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Privacy")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+
+            HStack(spacing: 12) {
+                iconCircle("person.2.fill", bg: Color(hex: "#F3F3F3"), fg: Color(hex: "#6B6B6B"))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Travel Comparison")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                    Text(allowComparison ? "Others can compare with you" : "Your travel data is private")
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                }
+                Spacer()
+                Toggle("", isOn: Binding(
+                    get: { pendingComparisonValue ?? allowComparison },
+                    set: { newValue in
+                        guard !isSavingComparison else { return }
+                        pendingComparisonValue = newValue
+                        Task { await updateComparisonSetting(newValue) }
+                    }
+                ))
+                .labelsHidden()
+                .disabled(isLoadingProfile || isSavingComparison)
+            }
+            .padding(16)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+        }
+    }
+
+    // MARK: - Settings Card
+
+    private var settingsCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Settings")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+
+            Button { showingChangePassword = true } label: {
+                HStack(spacing: 12) {
+                    iconCircle("key.fill", bg: Color(hex: "#F3F3F3"), fg: Color(hex: "#6B6B6B"))
+                    Text("Change Password")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                }
+                .padding(16)
+                .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Sign Out Card
+
+    private var signOutCard: some View {
+        Button {
+            do {
+                try authService.signOut()
+                appState.clearLocalDataAfterSignOut()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        } label: {
+            Text("Sign Out")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 18)
+                .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Icon Circle
+
+    private func iconCircle(_ systemImage: String, bg: Color, fg: Color) -> some View {
+        ZStack {
+            Circle().fill(bg).frame(width: 40, height: 40)
+            Image(systemName: systemImage)
+                .font(.system(size: 16))
+                .foregroundStyle(fg)
+        }
+    }
+
     // MARK: - Profile Management
-    
-    /// Load the current user's profile from Firestore
+
     private func loadProfile() async {
         isLoadingProfile = true
         defer { isLoadingProfile = false }
-        
         do {
             userProfile = try await profileRepository.getCurrentUserProfile()
             allowComparison = userProfile?.allowComparison ?? false
-            
-            #if DEBUG
-            if let profile = userProfile {
-                print("✅ Loaded profile: allowComparison = \(profile.allowComparison)")
-            } else {
-                print("ℹ️ No profile exists yet")
-            }
-            #endif
         } catch {
-            // Fail silently - profile is optional, don't break AccountScreen
-            #if DEBUG
-            print("⚠️ Failed to load profile: \(error.localizedDescription)")
-            #endif
             userProfile = nil
             allowComparison = false
         }
     }
-    
-    /// Update or create the comparison setting
-    /// If profile doesn't exist, create it first
+
     private func updateComparisonSetting(_ newValue: Bool) async {
-        await MainActor.run {
-            isSavingComparison = true
-        }
-        
-        // Create a timeout task
+        isSavingComparison = true
         let timeoutTask = Task {
-            try? await Task.sleep(nanoseconds: 10_000_000_000) // 10 seconds
-            await MainActor.run {
-                if isSavingComparison {
-                    pendingComparisonValue = nil
-                    errorMessage = "Request timed out. Please check your connection and try again."
-                    isSavingComparison = false
-                    
-                    #if DEBUG
-                    print("⏱️ Save operation timed out after 10 seconds")
-                    #endif
-                }
-            }
-        }
-        
-        do {
-            if let existingProfile = userProfile {
-                // Profile exists - just update the setting
-                try await profileRepository.updateComparisonSetting(allowComparison: newValue)
-                
-                // Cancel timeout and update local state on success
-                timeoutTask.cancel()
-                await MainActor.run {
-                    var updatedProfile = existingProfile
-                    updatedProfile.allowComparison = newValue
-                    updatedProfile.updatedAt = Date()
-                    userProfile = updatedProfile
-                    allowComparison = newValue
-                    pendingComparisonValue = nil
-                    
-                    // Clear any previous error
-                    errorMessage = nil
-                    isSavingComparison = false
-                }
-                
-                #if DEBUG
-                print("✅ Updated allowComparison to \(newValue)")
-                #endif
-            } else {
-                // Profile doesn't exist - create it
-                guard let user = authService.user else {
-                    timeoutTask.cancel()
-                    await MainActor.run {
-                        pendingComparisonValue = nil
-                        isSavingComparison = false
-                        errorMessage = "User not authenticated"
-                    }
-                    return
-                }
-                
-                let newProfile = UserProfile(
-                    userId: user.uid,
-                    email: authService.userEmail,
-                    allowComparison: newValue
-                )
-                
-                try await profileRepository.createOrUpdateProfile(newProfile)
-                
-                // Cancel timeout and update local state on success
-                timeoutTask.cancel()
-                await MainActor.run {
-                    userProfile = newProfile
-                    allowComparison = newValue
-                    pendingComparisonValue = nil
-                    
-                    // Clear any previous error
-                    errorMessage = nil
-                    isSavingComparison = false
-                }
-                
-                #if DEBUG
-                print("✅ Created new profile with allowComparison = \(newValue)")
-                #endif
-            }
-        } catch {
-            // Cancel timeout and revert to previous state on error
-            timeoutTask.cancel()
-            await MainActor.run {
+            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            if isSavingComparison {
                 pendingComparisonValue = nil
-                errorMessage = "Failed to update privacy setting: \(error.localizedDescription)"
+                errorMessage = "Request timed out. Please check your connection and try again."
                 isSavingComparison = false
             }
-            
-            #if DEBUG
-            print("❌ Failed to update comparison setting: \(error.localizedDescription)")
-            print("   Reverted to previous value: \(allowComparison)")
-            #endif
         }
-    }
-    
-    // MARK: - Email Lookup Testing
-    
-    /// Test function to lookup a user by email
-    private func testEmailLookup() async {
-        await MainActor.run {
-            isLookingUp = true
-            lookupResult = nil
-        }
-        
         do {
-            let profile = try await profileRepository.findProfileByEmail(testEmail)
-            
-            await MainActor.run {
-                if let profile {
-                    lookupResult = "✅ Found: \(profile.email)\nUser ID: \(profile.id)\nComparison allowed: \(profile.allowComparison)"
-                    
-                    #if DEBUG
-                    print("✅ Lookup successful: \(profile.email)")
-                    print("   User ID: \(profile.id)")
-                    print("   Allow comparison: \(profile.allowComparison)")
-                    #endif
-                } else {
-                    lookupResult = "❌ No user found with email '\(testEmail)' or they have disabled comparison"
-                    
-                    #if DEBUG
-                    print("❌ No profile found for: \(testEmail)")
-                    #endif
+            if let existingProfile = userProfile {
+                try await profileRepository.updateComparisonSetting(allowComparison: newValue)
+                timeoutTask.cancel()
+                var updated = existingProfile
+                updated.allowComparison = newValue
+                updated.updatedAt = Date()
+                userProfile = updated
+                allowComparison = newValue
+                pendingComparisonValue = nil
+                errorMessage = nil
+                isSavingComparison = false
+            } else {
+                guard let user = authService.user else {
+                    timeoutTask.cancel()
+                    pendingComparisonValue = nil
+                    isSavingComparison = false
+                    errorMessage = "User not authenticated"
+                    return
                 }
-                isLookingUp = false
+                let newProfile = UserProfile(userId: user.uid, email: authService.userEmail, allowComparison: newValue)
+                try await profileRepository.createOrUpdateProfile(newProfile)
+                timeoutTask.cancel()
+                userProfile = newProfile
+                allowComparison = newValue
+                pendingComparisonValue = nil
+                errorMessage = nil
+                isSavingComparison = false
             }
         } catch {
-            await MainActor.run {
-                lookupResult = "❌ Error: \(error.localizedDescription)"
-                isLookingUp = false
-                
-                #if DEBUG
-                print("❌ Lookup error: \(error.localizedDescription)")
-                #endif
-            }
-        }
-    }
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                // MARK: - Profile Section
-                Section {
-                    VStack(spacing: 12) {
-                        // Avatar Circle with Initials
-                        ZStack {
-                            Circle()
-                                .fill(avatarColor(for: authService.userEmail))
-                                .frame(width: 64, height: 64)
-                            
-                            Text(initials(from: authService.userEmail))
-                                .font(.system(size: 24, weight: .bold))
-                                .foregroundStyle(.white)
-                        }
-                        .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-                        
-                        // Email
-                        Text(authService.userEmail)
-                            .font(.body)
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                }
-                
-                // MARK: - Travel Overview Section
-                Section {
-                    // Visited Countries
-                    HStack(spacing: 12) {
-                        Image(systemName: "globe.americas.fill")
-                            .font(.title2)
-                            .foregroundStyle(.green)
-                            .frame(width: 32)
-                        
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("\(visitedCount) Countries Visited")
-                                .font(.headline)
-                            
-                            Text("\(visitedPercentage, specifier: "%.1f")% of the world")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                        }
-                        
-                        Spacer()
-                    }
-                    .padding(.vertical, 4)
-                    
-                    // Progress Bar
-                    VStack(alignment: .leading, spacing: 8) {
-                        GeometryReader { geometry in
-                            ZStack(alignment: .leading) {
-                                RoundedRectangle(cornerRadius: 4)
-                                    .fill(Color.gray.opacity(0.2))
-                                    .frame(height: 8)
-                                
-                                RoundedRectangle(cornerRadius: 4)
-                                    .fill(Color.green)
-                                    .frame(width: geometry.size.width * (visitedPercentage / 100), height: 8)
-                            }
-                        }
-                        .frame(height: 8)
-                    }
-                    
-                    // Wishlist Countries
-                    HStack(spacing: 12) {
-                        Image(systemName: "star.fill")
-                            .font(.title2)
-                            .foregroundStyle(.orange)
-                            .frame(width: 32)
-                        
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("\(wishlistCount) Countries on Wishlist")
-                                .font(.headline)
-                            
-                            if wishlistCount > 0 {
-                                Text("Places to visit next")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            } else {
-                                Text("Start planning your next trip")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        
-                        Spacer()
-                    }
-                    .padding(.vertical, 4)
-                } header: {
-                    Text("Travel Overview")
-                } footer: {
-                    if visitedCount == 0 && wishlistCount == 0 {
-                        Text("Start marking countries as visited to track your travel journey!")
-                    }
-                }
-                
-                // MARK: - Travel Highlights Section
-                Section {
-                    // Visited This Year
-                    HStack(spacing: 12) {
-                        Image(systemName: "calendar")
-                            .font(.title2)
-                            .foregroundStyle(.blue)
-                            .frame(width: 32)
-                        
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("\(visitedThisYear) Visited This Year")
-                                .font(.headline)
-                            
-                            if visitedThisYear > 0 {
-                                Text("Great travel year!")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            } else {
-                                let currentYear = Calendar.current.component(.year, from: Date())
-                                Text("Start your \(String(format: "%d", currentYear)) travels")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        
-                        Spacer()
-                    }
-                    .padding(.vertical, 4)
-                    
-                    // Achievements
-                    HStack(spacing: 12) {
-                        Image(systemName: "trophy.fill")
-                            .font(.title2)
-                            .foregroundStyle(.yellow)
-                            .frame(width: 32)
-                        
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("\(achievementSummary.unlocked)/\(achievementSummary.total) Achievements")
-                                .font(.headline)
-                            
-                            if achievementSummary.unlocked > 0 {
-                                Text("Keep exploring!")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            } else {
-                                Text("Unlock your first achievement")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        
-                        Spacer()
-                    }
-                    .padding(.vertical, 4)
-                } header: {
-                    Text("Travel Highlights")
-                }
-                
-                // MARK: - Privacy Section
-                Section {
-                    Toggle(isOn: Binding(
-                        get: { 
-                            // Show pending value if one exists, otherwise current value
-                            pendingComparisonValue ?? allowComparison 
-                        },
-                        set: { newValue in
-                            // Don't allow changes while saving
-                            guard !isSavingComparison else { return }
-                            
-                            // Set pending value for immediate UI feedback
-                            pendingComparisonValue = newValue
-                            
-                            // Save to Firestore asynchronously
-                            Task {
-                                await updateComparisonSetting(newValue)
-                            }
-                        }
-                    )) {
-                        HStack(spacing: 12) {
-                            Image(systemName: "person.2.fill")
-                                .font(.title2)
-                                .foregroundStyle(.purple)
-                                .frame(width: 32)
-                            
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Allow Travel Comparison")
-                                    .font(.headline)
-                                
-                                if isLoadingProfile {
-                                    Text("Loading...")
-                                        .font(.subheadline)
-                                        .foregroundStyle(.secondary)
-                                } else if isSavingComparison {
-                                    Text("Saving...")
-                                        .font(.subheadline)
-                                        .foregroundStyle(.secondary)
-                                } else {
-                                    Text(allowComparison ? "Others can compare with you" : "Your travel data is private")
-                                        .font(.subheadline)
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-                        }
-                        .padding(.vertical, 4)
-                    }
-                    .disabled(isLoadingProfile || isSavingComparison)
-                } header: {
-                    Text("Privacy")
-                } footer: {
-                    Text("When enabled, friends can compare their travel history with yours. Your travel data remains private when disabled.")
-                }
-                
-                // MARK: - Email Lookup Test Section (DEBUG ONLY)
-                #if DEBUG
-                Section {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Test Email Lookup")
-                            .font(.headline)
-                        
-                        TextField("Enter email to lookup", text: $testEmail)
-                            .textFieldStyle(.roundedBorder)
-                            .autocapitalization(.none)
-                            .keyboardType(.emailAddress)
-                            .disabled(isLookingUp)
-                        
-                        Button {
-                            Task {
-                                await testEmailLookup()
-                            }
-                        } label: {
-                            HStack {
-                                if isLookingUp {
-                                    ProgressView()
-                                        .scaleEffect(0.8)
-                                }
-                                Text(isLookingUp ? "Searching..." : "Lookup User")
-                            }
-                            .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .disabled(testEmail.isEmpty || isLookingUp)
-                        
-                        if let result = lookupResult {
-                            Text(result)
-                                .font(.caption)
-                                .foregroundStyle(result.hasPrefix("✅") ? .green : .red)
-                                .padding(.top, 4)
-                        }
-                    }
-                    .padding(.vertical, 8)
-                } header: {
-                    Text("Developer Tools")
-                } footer: {
-                    Text("This section is only visible in DEBUG builds. Test the email lookup functionality here.")
-                }
-                #endif
-
-                // MARK: - Settings Section
-                Section {
-                    Button {
-                        showingChangePassword = true
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: "key.fill")
-                                .font(.title2)
-                                .foregroundStyle(.blue)
-                                .frame(width: 32)
-                            
-                            Text("Change Password")
-                                .foregroundStyle(.primary)
-                            
-                            Spacer()
-                        }
-                        .padding(.vertical, 4)
-                    }
-                } header: {
-                    Text("Settings")
-                }
-
-                // MARK: - Sign Out Section
-                Section {
-                    Button("Sign Out", role: .destructive) {
-                        do {
-                            try authService.signOut()
-                            appState.clearLocalDataAfterSignOut()
-                        } catch {
-                            errorMessage = error.localizedDescription
-                        }
-                    }
-                }
-                
-                // MARK: - Danger Zone Section
-                Section {
-                    Button {
-                        showingDeleteAccount = true
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .font(.title2)
-                                .foregroundStyle(.red)
-                                .frame(width: 32)
-                            
-                            Text("Delete Account")
-                                .foregroundStyle(.red)
-                            
-                            Spacer()
-                        }
-                        .padding(.vertical, 4)
-                    }
-                } header: {
-                    Text("Danger Zone")
-                        .foregroundStyle(.red)
-                } footer: {
-                    Text("Deleting your account is permanent and cannot be undone. All your travel data will be lost.")
-                        .foregroundStyle(.red)
-                }
-
-                // MARK: - Error Section
-                if let errorMessage {
-                    Section("Error") {
-                        Text(errorMessage)
-                            .foregroundStyle(.red)
-                    }
-                }
-            }
-            .navigationTitle("Account")
-            .sheet(isPresented: $showingChangePassword) {
-                ChangePasswordView()
-            }
-            .sheet(isPresented: $showingDeleteAccount) {
-                DeleteAccountView()
-            }
-            .task {
-                // Load countries and total count from CountryDataService
-                let loadedCountries = CountryDataService.shared.loadCountries()
-                countries = loadedCountries
-                totalCountries = loadedCountries.count
-                
-                // Load user profile for privacy settings
-                await loadProfile()
-            }
+            timeoutTask.cancel()
+            pendingComparisonValue = nil
+            errorMessage = "Failed to update privacy setting: \(error.localizedDescription)"
+            isSavingComparison = false
         }
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
@@ -11,170 +11,253 @@ struct AuthScreen: View {
     @EnvironmentObject private var authService: AuthService
     @EnvironmentObject private var appState: AppState
 
+    @State private var firstName = ""
+    @State private var lastName = ""
     @State private var email = ""
     @State private var password = ""
     @State private var isCreatingAccount = false
     @State private var errorMessage: String?
     @State private var isSubmitting = false
+    @State private var showPassword = false
 
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                // MARK: - Top Spacer (Adaptive)
-                Spacer()
-                    .frame(height: 60)
-                
-                // MARK: - Branding Header
-                VStack(spacing: 16) {
-                    // App Logo
-                    AppLogoView()
-                    
-                    // App Name
-                    Text("WorldTracker")
-                        .font(.system(size: 32, weight: .bold))
-                        .foregroundStyle(.primary)
-                    
-                    // Tagline
-                    Text("Track your travels around the world")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 32)
+
+                // MARK: - Wordmark
+                Text("WORLDTRACKER")
+                    .font(.custom("Inter", size: 12))
+                    .fontWeight(.bold)
+                    .tracking(3.5)
+                    .foregroundStyle(.black)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .frame(height: 64)
+
+                // MARK: - Headline
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(isCreatingAccount ? "Create your account." : "Track every place you've been.")
+                        .font(.custom("Inter", size: 32))
+                        .fontWeight(.bold)
+                        .foregroundStyle(.black)
+                        .tracking(-0.5)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text("Your world, mapped.")
+                        .font(.custom("Inter", size: 15))
+                        .foregroundStyle(Color(hex: "#6B6B6B"))
                 }
-                .padding(.bottom, 48)
-                
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 24)
+                .padding(.top, 48)
+                .padding(.bottom, 32)
+
                 // MARK: - Input Fields
-                VStack(spacing: 16) {
-                    // Email Field
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Email")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.secondary)
-                        
-                        TextField("Email", text: $email)
-                            .textInputAutocapitalization(.never)
-                            .keyboardType(.emailAddress)
-                            .autocorrectionDisabled()
-                            .padding()
-                            .background(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .fill(Color(.systemBackground))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 12)
-                                            .strokeBorder(Color(.separator), lineWidth: 1)
-                                    )
-                                    .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 2)
-                            )
+                VStack(spacing: 12) {
+                    // Name fields (sign up only)
+                    if isCreatingAccount {
+                        HStack(spacing: 12) {
+                            TextField("First Name", text: $firstName)
+                                .font(.custom("Inter", size: 16))
+                                .textInputAutocapitalization(.words)
+                                .autocorrectionDisabled()
+                                .padding(.horizontal, 16)
+                                .frame(height: 52)
+                                .background(Color(hex: "#F3F3F3"))
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                            TextField("Last Name", text: $lastName)
+                                .font(.custom("Inter", size: 16))
+                                .textInputAutocapitalization(.words)
+                                .autocorrectionDisabled()
+                                .padding(.horizontal, 16)
+                                .frame(height: 52)
+                                .background(Color(hex: "#F3F3F3"))
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                        }
                     }
-                    
-                    // Password Field
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Password")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundStyle(.secondary)
-                        
-                        SecureField("Password", text: $password)
-                            .padding()
-                            .background(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .fill(Color(.systemBackground))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 12)
-                                            .strokeBorder(Color(.separator), lineWidth: 1)
-                                    )
-                                    .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 2)
-                            )
+
+                    // Email
+                    TextField("Email", text: $email)
+                        .font(.custom("Inter", size: 16))
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.emailAddress)
+                        .autocorrectionDisabled()
+                        .padding(.horizontal, 16)
+                        .frame(height: 52)
+                        .background(Color(hex: "#F3F3F3"))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                    // Password
+                    ZStack(alignment: .trailing) {
+                        Group {
+                            if showPassword {
+                                TextField("Password", text: $password)
+                            } else {
+                                SecureField("Password", text: $password)
+                            }
+                        }
+                        .font(.custom("Inter", size: 16))
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .padding(.horizontal, 16)
+                        .padding(.trailing, 44)
+                        .frame(height: 52)
+
+                        Button {
+                            showPassword.toggle()
+                        } label: {
+                            Image(systemName: showPassword ? "eye" : "eye.slash")
+                                .font(.system(size: 16))
+                                .foregroundStyle(Color(hex: "#6B6B6B"))
+                        }
+                        .padding(.trailing, 16)
                     }
+                    .frame(height: 52)
+                    .background(Color(hex: "#F3F3F3"))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
-                .padding(.horizontal, 32)
-                
+                .padding(.horizontal, 24)
+
                 // MARK: - Error Message
                 if let errorMessage {
-                    HStack(spacing: 8) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.subheadline)
-                        
-                        Text(errorMessage)
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                    }
-                    .foregroundStyle(.red)
-                    .padding()
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(Color.red.opacity(0.08))
-                    )
-                    .padding(.horizontal, 32)
-                    .padding(.top, 16)
-                    .transition(.move(edge: .top).combined(with: .opacity))
+                    Text(errorMessage)
+                        .font(.custom("Inter", size: 13))
+                        .foregroundStyle(.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 24)
+                        .padding(.top, 8)
+                        .transition(.opacity)
                 }
-                
-                // MARK: - Primary Action Button
+
+                // MARK: - Continue Button
                 Button {
-                    Task {
-                        await submit()
-                    }
+                    Task { await submit() }
                 } label: {
                     HStack(spacing: 8) {
                         if isSubmitting {
-                            ProgressView()
-                                .tint(.white)
+                            ProgressView().tint(.white)
                         }
-                        
-                        Text(isCreatingAccount ? "Create Account" : "Sign In")
-                            .font(.headline)
+                        Text(isCreatingAccount ? "Create Account" : "Continue")
+                            .font(.custom("Inter", size: 16))
                             .fontWeight(.semibold)
                     }
                     .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(
-                                LinearGradient(
-                                    colors: [.blue, .cyan],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                            )
-                    )
+                    .frame(height: 52)
+                    .background(Color.black)
                     .foregroundStyle(.white)
-                    .shadow(color: .blue.opacity(0.3), radius: 8, x: 0, y: 4)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
-                .disabled(email.isEmpty || password.isEmpty || isSubmitting)
-                .opacity((email.isEmpty || password.isEmpty || isSubmitting) ? 0.6 : 1.0)
-                .padding(.horizontal, 32)
-                .padding(.top, errorMessage == nil ? 32 : 16)
-                
-                // MARK: - Secondary Toggle Action
+                .disabled(!isFormReady)
+                .opacity(isFormReady ? 1.0 : 0.5)
+                .padding(.horizontal, 24)
+                .padding(.top, 12)
+
+                // MARK: - Forgot Password
+                if !isCreatingAccount {
+                    Button {
+                        // TODO: forgot password flow
+                    } label: {
+                        Text("Forgot password?")
+                            .font(.custom("Inter", size: 14))
+                            .fontWeight(.bold)
+                            .foregroundStyle(Color(hex: "#6B6B6B"))
+                    }
+                    .padding(.top, 20)
+                }
+
+                // MARK: - OR Divider
+                HStack(spacing: 16) {
+                    Rectangle()
+                        .fill(Color(hex: "#EEEEEE"))
+                        .frame(height: 1)
+                    Text("OR")
+                        .font(.custom("Inter", size: 12))
+                        .fontWeight(.bold)
+                        .foregroundStyle(Color(hex: "#6B6B6B"))
+                        .tracking(2)
+                    Rectangle()
+                        .fill(Color(hex: "#EEEEEE"))
+                        .frame(height: 1)
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 28)
+
+                // MARK: - Social Buttons
+                VStack(spacing: 12) {
+                    // Google
+                    Button {
+                        // TODO: Google sign-in
+                    } label: {
+                        HStack(spacing: 12) {
+                            GoogleLogoView()
+                            Text("Continue with Google")
+                                .font(.custom("Inter", size: 16))
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.black)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .background(Color(hex: "#F5F5F5"))
+                        .clipShape(Capsule())
+                    }
+
+                    // Apple
+                    Button {
+                        // TODO: Apple sign-in
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "apple.logo")
+                                .font(.system(size: 18, weight: .medium))
+                                .foregroundStyle(.black)
+                            Text("Continue with Apple")
+                                .font(.custom("Inter", size: 16))
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.black)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .background(Color(hex: "#F5F5F5"))
+                        .clipShape(Capsule())
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 24)
+
+                // MARK: - Sign Up / Sign In Toggle
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         isCreatingAccount.toggle()
                         errorMessage = nil
+                        firstName = ""
+                        lastName = ""
                     }
                 } label: {
-                    Text(isCreatingAccount 
-                         ? "Already have an account? **Sign in**"
-                         : "Need an account? **Sign up**")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
+                    Group {
+                        if isCreatingAccount {
+                            Text("Already have an account? ") + Text("Sign in").fontWeight(.semibold).foregroundColor(.black)
+                        } else {
+                            Text("Don't have an account? ") + Text("Sign up").fontWeight(.semibold).foregroundColor(.black)
+                        }
+                    }
+                    .font(.custom("Inter", size: 15))
+                    .foregroundStyle(Color(hex: "#6B6B6B"))
                 }
                 .disabled(isSubmitting)
-                .padding(.top, 24)
-                .padding(.horizontal, 32)
-                
-                // MARK: - Bottom Spacer
-                Spacer()
-                    .frame(height: 60)
+                .padding(.top, 32)
+                .padding(.bottom, 48)
             }
-            .frame(maxWidth: 500) // Max width for larger devices
-            .frame(maxWidth: .infinity) // Center on wide screens
+            .frame(maxWidth: .infinity)
         }
         .scrollDismissesKeyboard(.interactively)
-        .background(Color(.systemGroupedBackground))
+        .background(Color.white)
+    }
+
+    private var isFormReady: Bool {
+        let base = !email.isEmpty && !password.isEmpty && !isSubmitting
+        if isCreatingAccount {
+            return base && !firstName.isEmpty && !lastName.isEmpty
+        }
+        return base
     }
 
     private func submit() async {
@@ -187,7 +270,7 @@ struct AuthScreen: View {
 
         do {
             if isCreatingAccount {
-                try await authService.signUp(email: email, password: password)
+                try await authService.signUp(email: email, password: password, firstName: firstName, lastName: lastName)
             } else {
                 try await authService.signIn(email: email, password: password)
             }
@@ -263,6 +346,44 @@ struct AuthScreen: View {
         // Fallback to original error message
         return error.localizedDescription
     }
+}
+
+// MARK: - Google Logo View
+
+private struct GoogleLogoView: View {
+    var body: some View {
+        // Standard 4-color Google "G" rendered as colored arc segments
+        ZStack {
+            ForEach(Array(googleSegments.enumerated()), id: \.offset) { _, seg in
+                Path { path in
+                    path.move(to: CGPoint(x: 10, y: 10))
+                    path.addArc(center: CGPoint(x: 10, y: 10),
+                                radius: 10,
+                                startAngle: .degrees(seg.start),
+                                endAngle: .degrees(seg.end),
+                                clockwise: false)
+                    path.closeSubpath()
+                }
+                .fill(seg.color)
+            }
+            // White inner circle to create ring effect
+            Circle()
+                .fill(Color(hex: "#F5F5F5"))
+                .frame(width: 12, height: 12)
+            Text("G")
+                .font(.system(size: 8, weight: .bold))
+                .foregroundStyle(Color(red: 0.259, green: 0.522, blue: 0.957))
+        }
+        .frame(width: 20, height: 20)
+    }
+
+    private struct Segment { let start: Double; let end: Double; let color: Color }
+    private var googleSegments: [Segment] { [
+        Segment(start: -90, end:   0, color: Color(red: 0.259, green: 0.522, blue: 0.957)), // Blue
+        Segment(start:   0, end:  90, color: Color(red: 0.204, green: 0.659, blue: 0.325)), // Green
+        Segment(start:  90, end: 180, color: Color(red: 0.984, green: 0.737, blue: 0.020)), // Yellow
+        Segment(start: 180, end: 270, color: Color(red: 0.918, green: 0.263, blue: 0.208)), // Red
+    ] }
 }
 
 // MARK: - App Logo View

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Countries/CountriesScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Countries/CountriesScreen.swift
@@ -7,212 +7,171 @@
 
 import SwiftUI
 
+// MARK: - Countries Screen
+
 struct CountriesScreen: View {
     @EnvironmentObject private var appState: AppState
     @StateObject private var vm = CountriesViewModel()
-    @State private var isSearchFocused = false
-    
+
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                // Continent filter chips - shown when search is active
-                if isSearchFocused || vm.isSearching {
-                    continentFilterChips
-                        .padding(.horizontal)
-                        .padding(.vertical, 8)
-                        .background(Color(.systemGroupedBackground))
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                }
-                
-                ZStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    // Search bar
+                    searchBar
+                        .padding(.horizontal, 16)
+                        .padding(.top, 16)
+
+                    // Continent filter chips
+                    continentChips
+                        .padding(.top, 12)
+
                     if vm.isSearching {
-                        // Show flat list when searching
-                        searchResultsList
-                            .transition(.opacity)
+                        searchResults
+                            .padding(.top, 12)
                     } else {
-                        // Show continent grid when not searching
+                        summaryLabel
+                            .padding(.horizontal, 20)
+                            .padding(.top, 20)
+                            .padding(.bottom, 12)
+
                         continentGrid
-                            .transition(.opacity)
-                    }
-                    
-                    if vm.isLoading {
-                        VStack(spacing: 16) {
-                            ProgressView()
-                                .scaleEffect(1.5)
-                            Text("Loading countries...")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(Color(.systemBackground).opacity(0.9))
+                            .padding(.horizontal, 16)
                     }
                 }
+                .padding(.bottom, 32)
             }
-            .animation(.easeInOut(duration: 0.25), value: isSearchFocused)
-            .animation(.easeInOut(duration: 0.25), value: vm.isSearching)
+            .background(Color(hex: "#F7F7F7"))
             .navigationTitle("Countries")
-            .searchable(text: $vm.searchText, isPresented: $isSearchFocused, prompt: "Search countries")
-            .onChange(of: vm.isSearching) { oldValue, newValue in
-                // Reset continent filter when search is cleared
-                if !newValue && vm.selectedContinent != nil {
-                    vm.selectedContinent = nil
-                }
-            }
-            .onChange(of: isSearchFocused) { oldValue, newValue in
-                // Reset continent filter when search is dismissed (Cancel button)
-                if !newValue && vm.selectedContinent != nil {
-                    vm.selectedContinent = nil
-                }
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        vm.load()
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                    }
-                    .disabled(vm.isLoading)
-                }
-            }
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear { vm.load() }
         }
     }
-    
-    // MARK: - Continent Filter Chips
-    
-    private var continentFilterChips: some View {
+
+    // MARK: Search Bar
+
+    private var searchBar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 16))
+                .foregroundStyle(Color(hex: "#6B6B6B"))
+            TextField("Search countries...", text: $vm.searchText)
+                .font(.system(size: 16))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+            if !vm.searchText.isEmpty {
+                Button { vm.searchText = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 44)
+        .background(Color(hex: "#EEEEEE"))
+        .clipShape(Capsule())
+    }
+
+    // MARK: Continent Chips
+
+    private var continentChips: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                // "All" chip
-                FilterChip(
-                    title: "All",
-                    isSelected: vm.selectedContinent == nil,
-                    action: {
-                        vm.selectedContinent = nil
+                continentChip("All", isSelected: vm.selectedContinent == nil) {
+                    vm.selectedContinent = nil
+                }
+                ForEach(Continent.allCases) { c in
+                    continentChip(c.displayName, isSelected: vm.selectedContinent == c) {
+                        vm.selectedContinent = c
                     }
-                )
-                
-                // Individual continent chips
-                ForEach(Continent.allCases) { continent in
-                    FilterChip(
-                        title: continent.displayName,
-                        isSelected: vm.selectedContinent == continent,
-                        action: {
-                            vm.selectedContinent = continent
-                        }
-                    )
                 }
             }
-            .padding(.horizontal, 4)
+            .padding(.horizontal, 16)
         }
     }
-    
-    // MARK: - Continent Grid View
-    
+
+    private func continentChip(_ title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(isSelected ? .white : Color(hex: "#6B6B6B"))
+                .padding(.horizontal, 18)
+                .padding(.vertical, 8)
+                .background(isSelected ? Color.black : Color.white)
+                .clipShape(Capsule())
+                .overlay(Capsule().stroke(isSelected ? Color.clear : Color(hex: "#E2E2E2"), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: Summary Label
+
+    private var summaryLabel: some View {
+        let allCountries = vm.countries
+        let totalVisited = allCountries.filter { appState.isVisited($0.id) }.count
+        let continentsWithVisit = Set(
+            allCountries.filter { appState.isVisited($0.id) }.map { $0.continent }
+        ).count
+
+        return Text("\(continentsWithVisit) CONTINENTS · \(totalVisited) COUNTRIES VISITED")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(Color(hex: "#9E9E9E"))
+            .tracking(0.5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Continent Grid
+
     private var continentGrid: some View {
-        ScrollView {
-            LazyVGrid(columns: [
-                GridItem(.flexible()),
-                GridItem(.flexible())
-            ], spacing: 16) {
-                ForEach(vm.groupedByContinent, id: \.continent.id) { section in
+        LazyVGrid(
+            columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)],
+            spacing: 12
+        ) {
+            ForEach(vm.groupedByContinent, id: \.continent.id) { section in
+                NavigationLink {
+                    ContinentCountriesView(
+                        continent: section.continent,
+                        countries: section.countries
+                    )
+                } label: {
+                    ContinentCard(
+                        continent: section.continent,
+                        totalCount: section.countries.count,
+                        visitedCount: section.countries.filter { appState.isVisited($0.id) }.count
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: Search Results
+
+    private var searchResults: some View {
+        VStack(spacing: 8) {
+            if vm.filteredCountries.isEmpty {
+                Text("No countries match \"\(vm.searchText)\"")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .padding(.top, 40)
+                    .frame(maxWidth: .infinity)
+            } else {
+                ForEach(vm.filteredCountries) { country in
                     NavigationLink {
-                        ContinentCountriesView(
-                            continent: section.continent,
-                            countries: section.countries,
-                            appState: appState
-                        )
+                        CountryDetailScreen(country: country)
                     } label: {
-                        ContinentCard(
-                            continent: section.continent,
-                            totalCount: section.countries.count,
-                            visitedCount: section.countries.filter { appState.isVisited($0.id) }.count
+                        CountryListRow(
+                            country: country,
+                            isVisited: appState.isVisited(country.id),
+                            isWishlist: appState.wantToVisit(country.id)
                         )
                     }
                     .buttonStyle(.plain)
                 }
             }
-            .padding()
         }
-        .overlay {
-            if !vm.isLoading && vm.groupedByContinent.isEmpty {
-                if let error = vm.loadError {
-                    ContentUnavailableView(
-                        "Failed to Load Countries",
-                        systemImage: "exclamationmark.triangle",
-                        description: Text(error)
-                    )
-                } else {
-                    ContentUnavailableView(
-                        "No Countries",
-                        systemImage: "globe",
-                        description: Text("No countries available.")
-                    )
-                }
-            }
-        }
-    }
-    
-    // MARK: - Search Results List
-    
-    private var searchResultsList: some View {
-        List {
-            // Result count section
-            Section {
-                EmptyView()
-            } header: {
-                resultCountHeader
-            }
-            .listRowInsets(EdgeInsets())
-            
-            // Country results
-            Section {
-                ForEach(vm.filteredCountries) { country in
-                    let visited = appState.isVisited(country.id)
-                    
-                    NavigationLink {
-                        CountryDetailScreen(country: country)
-                    } label: {
-                        CountryRow(country: country, isVisited: visited)
-                    }
-                    .listRowBackground(visited ? Color.green.opacity(0.12) : Color.clear)
-                }
-            }
-        }
-        .listStyle(.insetGrouped)
-        .overlay {
-            if !vm.isLoading && vm.filteredCountries.isEmpty {
-                ContentUnavailableView(
-                    "No Results",
-                    systemImage: "magnifyingglass",
-                    description: Text("No countries match your search")
-                )
-            }
-        }
-    }
-    
-    // MARK: - Result Count Header
-    
-    private var resultCountHeader: some View {
-        HStack {
-            let count = vm.filteredCountries.count
-            let filterText = vm.selectedContinent?.displayName ?? "All Continents"
-            
-            if count > 0 {
-                Text("\(count) \(count == 1 ? "country" : "countries")")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                
-                if vm.isFiltering {
-                    Text("•")
-                        .foregroundStyle(.secondary)
-                    Text(filterText)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
-        .textCase(nil)
-        .padding(.horizontal, 4)
+        .padding(.horizontal, 16)
     }
 }
 
@@ -222,171 +181,255 @@ private struct ContinentCard: View {
     let continent: Continent
     let totalCount: Int
     let visitedCount: Int
-    
-    var percentage: Double {
+
+    private var percentage: Double {
         guard totalCount > 0 else { return 0 }
-        return Double(visitedCount) / Double(totalCount) * 100
+        return Double(visitedCount) / Double(totalCount)
     }
-    
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // Header
-            HStack {
-                Text(continentEmoji)
-                    .font(.system(size: 32))
-                Spacer()
-            }
-            
-            // Title
+        VStack(alignment: .leading, spacing: 10) {
             Text(continent.displayName)
-                .font(.headline)
-                .foregroundStyle(.primary)
-            
-            // Stats
-            VStack(alignment: .leading, spacing: 4) {
-                Text("\(visitedCount) / \(totalCount)")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                
-                // Progress bar
-                GeometryReader { geometry in
-                    ZStack(alignment: .leading) {
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(Color.gray.opacity(0.2))
-                            .frame(height: 4)
-                        
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(continentColor)
-                            .frame(width: geometry.size.width * (percentage / 100), height: 4)
-                    }
-                }
-                .frame(height: 4)
-                
-                if visitedCount > 0 {
-                    Text("\(Int(percentage))% visited")
-                        .font(.caption)
-                        .foregroundStyle(continentColor)
-                } else {
-                    Text("Not visited yet")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundStyle(Color.black)
+                .tracking(-0.3)
+
+            // Progress bar
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(Color(hex: "#F0F0F0"))
+                        .frame(height: 4)
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(continentColor)
+                        .frame(width: max(geo.size.width * percentage, percentage > 0 ? 6 : 0), height: 4)
                 }
             }
+            .frame(height: 4)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(visitedCount) VISITED")
+                    .font(.system(size: 11, weight: .black))
+                    .foregroundStyle(continentColor)
+                    .tracking(0.3)
+                Text("of \(totalCount) \(totalCount == 1 ? "country" : "countries")")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+            }
         }
-        .padding()
+        .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(.secondarySystemGroupedBackground))
-        .cornerRadius(12)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
     }
-    
-    private var continentEmoji: String {
-        switch continent {
-        case .africa: return "🌍"
-        case .antarctica: return "🇦🇶"
-        case .asia: return "🌏"
-        case .europe: return "🇪🇺"
-        case .northAmerica: return "🌎"
-        case .southAmerica: return "🗺️"
-        case .oceania: return "🏝️"
-        }
-    }
-    
+
     private var continentColor: Color {
-        switch percentage {
-        case 75...: return .green
-        case 50..<75: return .blue
-        case 25..<50: return .orange
-        case 0.1..<25: return .yellow
-        default: return .gray
+        switch continent {
+        case .europe:       return Color(hex: "#F9234D")
+        case .asia:         return Color(hex: "#F1528A")
+        case .africa:       return Color(hex: "#E6A817")
+        case .oceania:      return Color(hex: "#1D8FC2")
+        case .northAmerica: return Color(hex: "#4A90D9")
+        case .southAmerica: return Color(hex: "#F37826")
+        case .antarctica:   return Color(hex: "#9E9E9E")
         }
     }
 }
 
 // MARK: - Continent Countries View
 
-private struct ContinentCountriesView: View {
+struct ContinentCountriesView: View {
+    @EnvironmentObject private var appState: AppState
     let continent: Continent
     let countries: [Country]
-    let appState: AppState
-    
+
     @State private var searchText = ""
-    
-    var filteredCountries: [Country] {
-        if searchText.isEmpty {
-            return countries
-        }
-        return countries.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    @State private var filterMode: FilterMode = .all
+
+    enum FilterMode: String, CaseIterable {
+        case all = "All"
+        case visited = "Visited"
+        case notVisited = "Not Visited"
+        case wishlist = "Wishlist"
     }
-    
+
+    private var filtered: [Country] {
+        var result = countries.sorted { $0.name < $1.name }
+        let trimmed = searchText.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty {
+            result = result.filter { $0.name.localizedCaseInsensitiveContains(trimmed) }
+        }
+        switch filterMode {
+        case .all:        break
+        case .visited:    result = result.filter { appState.isVisited($0.id) }
+        case .notVisited: result = result.filter { !appState.isVisited($0.id) }
+        case .wishlist:   result = result.filter { appState.wantToVisit($0.id) }
+        }
+        return result
+    }
+
+    private var groupedAlphabetically: [(letter: String, countries: [Country])] {
+        let grouped = Dictionary(grouping: filtered) { String($0.name.prefix(1)).uppercased() }
+        return grouped.keys.sorted().map { key in (key, grouped[key]!.sorted { $0.name < $1.name }) }
+    }
+
+    private var visitedCount: Int {
+        countries.filter { appState.isVisited($0.id) }.count
+    }
+
     var body: some View {
-        List {
-            ForEach(filteredCountries) { country in
-                let visited = appState.isVisited(country.id)
-                
-                NavigationLink {
-                    CountryDetailScreen(country: country)
-                } label: {
-                    CountryRow(country: country, isVisited: visited)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                // Search
+                searchBar
+                    .padding(.horizontal, 16)
+                    .padding(.top, 16)
+
+                // Filter chips
+                filterChips
+                    .padding(.top, 12)
+
+                // Summary
+                Text("\(visitedCount) of \(countries.count) countries visited in \(continent.displayName)")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .padding(.horizontal, 20)
+                    .padding(.top, 16)
+                    .padding(.bottom, 8)
+
+                // Alphabetical sections
+                if filtered.isEmpty {
+                    Text("No countries match your filter")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 40)
+                } else {
+                    VStack(alignment: .leading, spacing: 20) {
+                        ForEach(groupedAlphabetically, id: \.letter) { group in
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(group.letter)
+                                    .font(.system(size: 17, weight: .black))
+                                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                                    .padding(.horizontal, 16)
+
+                                VStack(spacing: 8) {
+                                    ForEach(group.countries) { country in
+                                        NavigationLink {
+                                            CountryDetailScreen(country: country)
+                                        } label: {
+                                            CountryListRow(
+                                                country: country,
+                                                isVisited: appState.isVisited(country.id),
+                                                isWishlist: appState.wantToVisit(country.id)
+                                            )
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                }
+                                .padding(.horizontal, 16)
+                            }
+                        }
+                    }
+                    .padding(.top, 4)
+                    .padding(.bottom, 32)
                 }
-                .listRowBackground(visited ? Color.green.opacity(0.12) : Color.clear)
             }
         }
+        .background(Color(hex: "#F7F7F7"))
         .navigationTitle(continent.displayName)
-        .searchable(text: $searchText, prompt: "Search \(continent.displayName)")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var searchBar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 16))
+                .foregroundStyle(Color(hex: "#6B6B6B"))
+            TextField("Search \(continent.displayName)...", text: $searchText)
+                .font(.system(size: 16))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+            if !searchText.isEmpty {
+                Button { searchText = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 44)
+        .background(Color(hex: "#EEEEEE"))
+        .clipShape(Capsule())
+    }
+
+    private var filterChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(FilterMode.allCases, id: \.self) { mode in
+                    Button {
+                        withAnimation(.spring(response: 0.3)) { filterMode = mode }
+                    } label: {
+                        Text(mode.rawValue)
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundStyle(filterMode == mode ? .white : .black)
+                            .padding(.horizontal, 18)
+                            .padding(.vertical, 8)
+                            .background(filterMode == mode ? Color.black : Color.white)
+                            .clipShape(Capsule())
+                            .overlay(filterMode == mode ? nil : Capsule().stroke(Color(hex: "#E2E2E2"), lineWidth: 1))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 16)
+        }
     }
 }
 
-// MARK: - Country Row
+// MARK: - Country List Row
 
-private struct CountryRow: View {
+struct CountryListRow: View {
     let country: Country
     let isVisited: Bool
-    
+    let isWishlist: Bool
+
     var body: some View {
         HStack(spacing: 12) {
-            Text(country.flagEmoji).font(.title2)
+            Text(country.flagEmoji)
+                .font(.system(size: 28))
+                .frame(width: 40, height: 36)
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(country.name)
-                    .foregroundStyle(.primary)
-            }
+            Text(country.name)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
 
             Spacer()
 
             if isVisited {
-                Text("Visited")
-                    .font(.caption2)
+                Text("VISITED")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(Color(hex: "#1E7F4E"))
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(.green.opacity(0.15))
-                    .clipShape(Capsule())
+                    .background(Color(hex: "#1E7F4E").opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            } else if isWishlist {
+                Image(systemName: "star.fill")
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color(hex: "#4A90D9"))
             }
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color(hex: "#CCCCCC"))
         }
-        .padding(.vertical, 4)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.03), radius: 4, x: 0, y: 1)
     }
 }
-
-// MARK: - Filter Chip
-
-private struct FilterChip: View {
-    let title: String
-    let isSelected: Bool
-    let action: () -> Void
-    
-    var body: some View {
-        Button(action: action) {
-            Text(title)
-                .font(.subheadline)
-                .fontWeight(isSelected ? .semibold : .regular)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-                .background(isSelected ? Color.accentColor : Color(.secondarySystemGroupedBackground))
-                .foregroundColor(isSelected ? .white : .primary)
-                .clipShape(Capsule())
-                .scaleEffect(isSelected ? 1.05 : 1.0)
-                .animation(.spring(response: 0.3, dampingFraction: 0.6), value: isSelected)
-        }
-        .buttonStyle(.plain)
-    }
-}
-

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryDetailScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryDetailScreen.swift
@@ -11,19 +11,19 @@ import PhotosUI
 struct CountryDetailScreen: View {
     @EnvironmentObject private var appState: AppState
     let country: Country
-    
-    @State private var selectedPhotoItem: PhotosPickerItem?
-    @State private var editingCaptionPhotoId: UUID?
-    @State private var editingCaption: String = ""
 
-    // MARK: - Clean bindings
+    @State private var selectedPhotoItem: PhotosPickerItem?
+    @State private var showDatePicker = false
+    @State private var fullScreenPhoto: VisitPhoto?
+    @State private var showAllPhotos = false
+
+    // MARK: - Bindings
 
     private var isVisited: Binding<Bool> {
         Binding(
             get: { appState.visit(for: country.id).isVisited },
             set: { newValue in
                 if newValue {
-                    // turning ON: keep existing date if present, otherwise default to today
                     let existing = appState.visit(for: country.id).visitedDate
                     appState.setVisited(country.id, isVisited: true, visitedDate: existing ?? Date())
                 } else {
@@ -36,9 +36,7 @@ struct CountryDetailScreen: View {
     private var visitDate: Binding<Date> {
         Binding(
             get: { appState.visit(for: country.id).visitedDate ?? Date() },
-            set: { newDate in
-                appState.setVisited(country.id, isVisited: true, visitedDate: newDate)
-            }
+            set: { appState.setVisited(country.id, isVisited: true, visitedDate: $0) }
         )
     }
 
@@ -48,198 +46,556 @@ struct CountryDetailScreen: View {
             set: { appState.updateNotes(country.id, notes: $0) }
         )
     }
-    
+
     private var wantToVisitBinding: Binding<Bool> {
         Binding(
             get: { appState.wantToVisit(country.id) },
             set: { appState.setWantToVisit(country.id, wantToVisit: $0) }
         )
     }
-    
+
     private var photos: [VisitPhoto] {
         appState.visits[country.id]?.photos ?? []
     }
 
+    // MARK: - Body
+
     var body: some View {
-        Form {
-            Section {
-                HStack(spacing: 12) {
-                    Text(country.flagEmoji)
-                        .font(.system(size: 44))
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(country.name)
-                            .font(.title2).bold()
-                        Text(country.continent.displayName)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .padding(.vertical, 4)
+        ScrollView {
+            VStack(spacing: 20) {
+                heroCard
+                statusCard
+                notesCard
+                photosCard
             }
-
-            Section("Travel Status") {
-                Toggle("Visited", isOn: isVisited)
-
-                if isVisited.wrappedValue {
-                    DatePicker(
-                        "Visit date",
-                        selection: visitDate,
-                        displayedComponents: [.date]
-                    )
-                }
-                
-                Toggle("Want to Visit", isOn: wantToVisitBinding)
-            }
-
-            Section("Notes") {
-                TextEditor(text: notes)
-                    .frame(minHeight: 120)
-            }
-
-            Section {
-                if photos.isEmpty {
-                    Text("No photos yet")
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding()
-                } else {
-                    ForEach(photos) { photo in
-                        photoRow(for: photo)
-                    }
-                }
-                
-                PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
-                    Label("Add Photo", systemImage: "photo.badge.plus")
-                }
-            } header: {
-                Text("Photos")
-            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            .padding(.bottom, 40)
         }
+        .background(Color(hex: "#F7F7F7"))
         .navigationTitle(country.name)
         .navigationBarTitleDisplayMode(.inline)
-        .onChange(of: selectedPhotoItem) { oldValue, newValue in
-            Task {
-                await loadPhoto(from: newValue)
+        .onChange(of: selectedPhotoItem) { _, newValue in
+            Task { await loadPhoto(from: newValue) }
+        }
+        .fullScreenCover(item: $fullScreenPhoto) { photo in
+            PhotoFullScreenView(photo: photo) {
+                appState.removePhoto(country.id, photoId: photo.id)
+                fullScreenPhoto = nil
+            }
+        }
+        .sheet(isPresented: $showAllPhotos) {
+            AllPhotosSheetView(photos: photos) { photoId in
+                appState.removePhoto(country.id, photoId: photoId)
             }
         }
     }
-    
+
+    // MARK: - Hero Card (dark, Compare-style)
+
+    private var heroCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                Text(country.flagEmoji)
+                    .font(.system(size: 56))
+                Spacer()
+                statusBadge
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(country.name)
+                    .font(.system(size: 26, weight: .bold))
+                    .foregroundStyle(.white)
+                    .tracking(-0.3)
+
+                Text(country.continent.displayName.uppercased())
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color.white.opacity(0.45))
+                    .tracking(1.5)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(Color(hex: "#111111"))
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
     @ViewBuilder
-    private func photoRow(for photo: VisitPhoto) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            if let uiImage = UIImage(data: photo.imageData) {
-                Image(uiImage: uiImage)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 200)
-                    .clipped()
-                    .cornerRadius(8)
+    private var statusBadge: some View {
+        if isVisited.wrappedValue {
+            Text("Visited")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color(hex: "#2E9E5B"))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color(hex: "#2E9E5B").opacity(0.18))
+                .clipShape(Capsule())
+        } else if wantToVisitBinding.wrappedValue {
+            Text("Wishlist")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color(hex: "#93E0FA"))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color(hex: "#93E0FA").opacity(0.18))
+                .clipShape(Capsule())
+        } else {
+            Text("Not Visited")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.white.opacity(0.5))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color.white.opacity(0.08))
+                .clipShape(Capsule())
+        }
+    }
+
+    // MARK: - Status Card
+
+    private var statusCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Travel Status")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+
+            VStack(spacing: 0) {
+                // Visited row
+                Button {
+                    withAnimation(.spring(response: 0.3)) {
+                        isVisited.wrappedValue.toggle()
+                        if isVisited.wrappedValue { wantToVisitBinding.wrappedValue = false }
+                    }
+                } label: {
+                    statusRow(
+                        icon: "checkmark.circle.fill",
+                        iconBg: isVisited.wrappedValue ? Color(hex: "#F0FFF4") : Color(hex: "#F3F3F3"),
+                        iconFg: isVisited.wrappedValue ? Color(hex: "#2E9E5B") : Color(hex: "#CCCCCC"),
+                        title: "Visited",
+                        checked: isVisited.wrappedValue,
+                        checkColor: Color(hex: "#2E9E5B")
+                    )
+                }
+                .buttonStyle(.plain)
+
+                Divider().padding(.horizontal, 16)
+
+                // Want to visit row
+                Button {
+                    withAnimation(.spring(response: 0.3)) {
+                        if !isVisited.wrappedValue {
+                            wantToVisitBinding.wrappedValue.toggle()
+                        }
+                    }
+                } label: {
+                    statusRow(
+                        icon: "star.fill",
+                        iconBg: wantToVisitBinding.wrappedValue ? Color(hex: "#EAF6FE") : Color(hex: "#F3F3F3"),
+                        iconFg: wantToVisitBinding.wrappedValue ? Color(hex: "#4A90D9") : Color(hex: "#CCCCCC"),
+                        title: "Want to Visit",
+                        titleColor: isVisited.wrappedValue ? Color(hex: "#CCCCCC") : Color(hex: "#1b1b1b"),
+                        checked: wantToVisitBinding.wrappedValue,
+                        checkColor: Color(hex: "#4A90D9")
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(isVisited.wrappedValue)
+
+                // Date row (visible when visited)
+                if isVisited.wrappedValue {
+                    Divider().padding(.horizontal, 16)
+
+                    HStack(spacing: 14) {
+                        ZStack {
+                            Circle().fill(Color(hex: "#EAF4FF")).frame(width: 40, height: 40)
+                            Image(systemName: "calendar")
+                                .font(.system(size: 16))
+                                .foregroundStyle(Color(hex: "#4A90D9"))
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Visit Date")
+                                .font(.system(size: 12))
+                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                            Text(visitDate.wrappedValue, format: .dateTime.month(.wide).day().year())
+                                .font(.system(size: 15, weight: .semibold))
+                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                        }
+                        Spacer()
+                        Button {
+                            withAnimation(.spring(response: 0.3)) { showDatePicker.toggle() }
+                        } label: {
+                            Text("Edit")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
+
+                    if showDatePicker {
+                        Divider().padding(.horizontal, 16)
+                        DatePicker("", selection: visitDate, displayedComponents: [.date])
+                            .datePickerStyle(.graphical)
+                            .padding(.horizontal, 16)
+                            .padding(.bottom, 8)
+                    }
+                }
             }
-            
-            if editingCaptionPhotoId == photo.id {
-                HStack {
-                    TextField("Caption", text: $editingCaption)
-                        .textFieldStyle(.roundedBorder)
-                    
-                    Button("Save") {
-                        appState.updatePhotoCaption(country.id, photoId: photo.id, caption: editingCaption)
-                        editingCaptionPhotoId = nil
-                        editingCaption = ""
-                    }
-                    .buttonStyle(.borderedProminent)
-                    
-                    Button("Cancel") {
-                        editingCaptionPhotoId = nil
-                        editingCaption = ""
-                    }
-                    .buttonStyle(.bordered)
-                }
-            } else {
-                HStack {
-                    if photo.caption.isEmpty {
-                        Text("Add caption...")
-                            .foregroundStyle(.secondary)
-                            .onTapGesture {
-                                editingCaptionPhotoId = photo.id
-                                editingCaption = photo.caption
-                            }
-                    } else {
-                        Text(photo.caption)
-                            .onTapGesture {
-                                editingCaptionPhotoId = photo.id
-                                editingCaption = photo.caption
-                            }
-                    }
-                    
-                    Spacer()
-                    
-                    Button(role: .destructive) {
-                        appState.removePhoto(country.id, photoId: photo.id)
-                    } label: {
-                        Image(systemName: "trash")
-                            .foregroundStyle(.red)
-                    }
-                }
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+        }
+    }
+
+    private func statusRow(
+        icon: String,
+        iconBg: Color,
+        iconFg: Color,
+        title: String,
+        titleColor: Color = Color(hex: "#1b1b1b"),
+        checked: Bool,
+        checkColor: Color
+    ) -> some View {
+        HStack(spacing: 14) {
+            ZStack {
+                Circle().fill(iconBg).frame(width: 40, height: 40)
+                Image(systemName: icon)
+                    .font(.system(size: 16))
+                    .foregroundStyle(iconFg)
+            }
+            Text(title)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(titleColor)
+            Spacer()
+            if checked {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(checkColor)
             }
         }
-        .padding(.vertical, 4)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .contentShape(Rectangle())
     }
-    
-    private func loadPhoto(from item: PhotosPickerItem?) async {
-        guard let item = item else { return }
-        
-        do {
-            guard let data = try await item.loadTransferable(type: Data.self) else {
-                return
+
+    // MARK: - Notes Card
+
+    private var notesCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Notes")
+                .font(.system(size: 17, weight: .bold))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+
+            ZStack(alignment: .topLeading) {
+                if notes.wrappedValue.isEmpty {
+                    Text("Add travel highlights, tips, and hidden gems for \(country.name)...")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .padding(.horizontal, 16)
+                        .padding(.top, 16)
+                        .allowsHitTesting(false)
+                }
+                TextEditor(text: notes)
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .frame(minHeight: 100)
+                    .padding(12)
+                    .scrollContentBackground(.hidden)
             }
-            
-            let compressedData = compressImage(data)
-            let photo = VisitPhoto(imageData: compressedData)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+        }
+    }
+
+    // MARK: - Photos Card
+
+    private var photosCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text("Photos")
+                    .font(.system(size: 17, weight: .bold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                Spacer()
+                PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 12, weight: .bold))
+                        Text("Add Photo")
+                            .font(.system(size: 13, weight: .semibold))
+                    }
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(Color(hex: "#EEEEEE"))
+                    .clipShape(Capsule())
+                }
+            }
+
+            if photos.isEmpty {
+                VStack(spacing: 12) {
+                    Image(systemName: "photo.stack")
+                        .font(.system(size: 36))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                    Text("No photos yet")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(40)
+                .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+            } else {
+                let displayed = Array(photos.prefix(4))
+                let remaining = max(0, photos.count - 4)
+                let cellSize = (UIScreen.main.bounds.width - 32 - 12) / 2
+                let rows = Int(ceil(Double(displayed.count) / 2.0))
+                let gridHeight = CGFloat(rows) * cellSize + CGFloat(rows - 1) * 12
+
+                VStack(spacing: 12) {
+                    ForEach(0..<rows, id: \.self) { row in
+                        HStack(spacing: 12) {
+                            ForEach(0..<2, id: \.self) { col in
+                                let idx = row * 2 + col
+                                if idx < displayed.count {
+                                    let isOverlay = idx == 3 && remaining > 0
+                                    photoCell(
+                                        photo: displayed[idx],
+                                        size: cellSize,
+                                        showOverlay: isOverlay,
+                                        remaining: remaining
+                                    ) {
+                                        if isOverlay { showAllPhotos = true }
+                                        else { fullScreenPhoto = displayed[idx] }
+                                    }
+                                } else {
+                                    Color.clear.frame(width: cellSize, height: cellSize)
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(height: gridHeight)
+            }
+        }
+    }
+
+    private func photoCell(photo: VisitPhoto, size: CGFloat, showOverlay: Bool, remaining: Int, onTap: @escaping () -> Void) -> some View {
+        Button { onTap() } label: {
+            ZStack {
+                Color(hex: "#EEEEEE")
+                if let uiImage = UIImage(data: photo.imageData) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: size, height: size)
+                        .clipped()
+                        .opacity(showOverlay ? 0.5 : 1.0)
+                }
+                if showOverlay {
+                    Color.black.opacity(0.3)
+                    Text("+\(remaining)")
+                        .font(.system(size: 22, weight: .black))
+                        .foregroundStyle(.white)
+                }
+            }
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Photo Loading
+
+    private func loadPhoto(from item: PhotosPickerItem?) async {
+        guard let item else { return }
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self) else { return }
+            let photo = VisitPhoto(imageData: compressImage(data))
             appState.addPhoto(country.id, photo: photo)
-            
             selectedPhotoItem = nil
         } catch {
             print("⚠️ Error loading photo: \(error)")
         }
     }
-    
+
     private func compressImage(_ data: Data) -> Data {
         guard var image = UIImage(data: data) else { return data }
-        
-        let maxSize: Int = 300_000 // ~400KB after Base64 encoding
+        let maxSize = 300_000
         let maxDimension: CGFloat = 1200
-        
-        // Resize if too large
         let size = image.size
         if size.width > maxDimension || size.height > maxDimension {
             let scale = min(maxDimension / size.width, maxDimension / size.height)
             let newSize = CGSize(width: size.width * scale, height: size.height * scale)
-            
             UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
             image.draw(in: CGRect(origin: .zero, size: newSize))
-            if let resizedImage = UIGraphicsGetImageFromCurrentImageContext() {
-                image = resizedImage
-            }
+            if let resized = UIGraphicsGetImageFromCurrentImageContext() { image = resized }
             UIGraphicsEndImageContext()
         }
-        
-        // Compress with JPEG quality
         var compression: CGFloat = 0.8
-        guard var imageData = image.jpegData(compressionQuality: compression) else {
-            return data
-        }
-        
-        // Reduce quality if still too large
+        guard var imageData = image.jpegData(compressionQuality: compression) else { return data }
         var attempts = 0
         while imageData.count > maxSize && compression > 0.1 && attempts < 10 {
             compression -= 0.1
-            if let compressedData = image.jpegData(compressionQuality: compression) {
-                imageData = compressedData
-            }
+            if let compressed = image.jpegData(compressionQuality: compression) { imageData = compressed }
             attempts += 1
         }
-        
         return imageData
+    }
+}
+
+// MARK: - Full Screen Photo Viewer
+
+struct PhotoFullScreenView: View {
+    let photo: VisitPhoto
+    let onDelete: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var scale: CGFloat = 1
+    @State private var offset: CGSize = .zero
+    @State private var showControls = true
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            if let uiImage = UIImage(data: photo.imageData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFit()
+                    .scaleEffect(scale)
+                    .offset(offset)
+                    .gesture(
+                        MagnificationGesture()
+                            .onChanged { scale = max(1, $0) }
+                            .onEnded { _ in
+                                withAnimation(.spring(response: 0.3)) {
+                                    if scale < 1.1 { scale = 1; offset = .zero }
+                                }
+                            }
+                            .simultaneously(with:
+                                DragGesture()
+                                    .onChanged { offset = scale > 1 ? $0.translation : .zero }
+                                    .onEnded { _ in
+                                        if scale <= 1 { withAnimation(.spring(response: 0.3)) { offset = .zero } }
+                                    }
+                            )
+                    )
+                    .onTapGesture {
+                        withAnimation(.easeInOut(duration: 0.2)) { showControls.toggle() }
+                    }
+            }
+
+            if showControls {
+                VStack {
+                    HStack {
+                        Button { dismiss() } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(.white)
+                                .frame(width: 36, height: 36)
+                                .background(Color.white.opacity(0.2))
+                                .clipShape(Circle())
+                        }
+                        .buttonStyle(.plain)
+                        Spacer()
+                        Button(role: .destructive) { onDelete() } label: {
+                            Image(systemName: "trash")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(.white)
+                                .frame(width: 36, height: 36)
+                                .background(Color.white.opacity(0.2))
+                                .clipShape(Circle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 16)
+                    Spacer()
+                }
+                .transition(.opacity)
+            }
+        }
+        .statusBarHidden()
+    }
+}
+
+// MARK: - All Photos Sheet
+
+struct AllPhotosSheetView: View {
+    let photos: [VisitPhoto]
+    let onDelete: (UUID) -> Void
+
+    @State private var selectedPhoto: VisitPhoto?
+    @Environment(\.dismiss) private var dismiss
+
+    private let spacing: CGFloat = 3
+    private var cellSize: CGFloat {
+        (UIScreen.main.bounds.width - spacing * 2) / 3
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("\(photos.count) Photos")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                Spacer()
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 26))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 16)
+
+            ScrollView {
+                let rows = Int(ceil(Double(photos.count) / 3.0))
+                VStack(spacing: spacing) {
+                    ForEach(0..<rows, id: \.self) { row in
+                        HStack(spacing: spacing) {
+                            ForEach(0..<3, id: \.self) { col in
+                                let idx = row * 3 + col
+                                if idx < photos.count {
+                                    Button { selectedPhoto = photos[idx] } label: {
+                                        photoThumb(photos[idx])
+                                    }
+                                    .buttonStyle(.plain)
+                                } else {
+                                    Color.clear.frame(width: cellSize, height: cellSize)
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, 20)
+            }
+        }
+        .background(Color(hex: "#F7F7F7"))
+        .fullScreenCover(item: $selectedPhoto) { photo in
+            PhotoFullScreenView(photo: photo) {
+                onDelete(photo.id)
+                selectedPhoto = nil
+            }
+        }
+    }
+
+    private func photoThumb(_ photo: VisitPhoto) -> some View {
+        ZStack {
+            Color(hex: "#EEEEEE")
+            if let uiImage = UIImage(data: photo.imageData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: cellSize, height: cellSize)
+                    .clipped()
+            }
+        }
+        .frame(width: cellSize, height: cellSize)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryMapPreviewBubble.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryMapPreviewBubble.swift
@@ -10,83 +10,53 @@ import MapKit
 
 // MARK: - Map Annotation Bubble (Always Visible)
 
-/// Compact bubble that appears as an annotation on the map for visited countries
 struct CountryMapAnnotationBubble: View {
     let country: Country
     let visit: Visit
-    
+
     var body: some View {
         VStack(spacing: 4) {
-            // Main bubble content
             HStack(spacing: 8) {
-                // Preview indicator
                 if let firstPhoto = visit.photos.first,
                    let uiImage = UIImage(data: firstPhoto.imageData) {
-                    // Photo thumbnail
                     Image(uiImage: uiImage)
                         .resizable()
                         .scaledToFill()
                         .frame(width: 40, height: 40)
                         .clipShape(Circle())
-                        .overlay(
-                            Circle()
-                                .stroke(Color.white, lineWidth: 2)
-                        )
-                } else if !visit.notes.isEmpty {
-                    // Note indicator
-                    ZStack {
-                        Circle()
-                            .fill(Color.blue.gradient)
-                            .frame(width: 40, height: 40)
-                        
-                        Image(systemName: "note.text")
-                            .font(.system(size: 18))
-                            .foregroundStyle(.white)
-                    }
-                    .overlay(
-                        Circle()
-                            .stroke(Color.white, lineWidth: 2)
-                    )
+                        .overlay(Circle().stroke(Color.white, lineWidth: 2))
                 } else {
-                    // Just visited indicator
                     ZStack {
                         Circle()
-                            .fill(Color.green.gradient)
+                            .fill(Color(hex: "#F9234D"))
                             .frame(width: 40, height: 40)
-                        
                         Text(country.flagEmoji)
                             .font(.system(size: 20))
                     }
-                    .overlay(
-                        Circle()
-                            .stroke(Color.white, lineWidth: 2)
-                    )
+                    .overlay(Circle().stroke(Color.white, lineWidth: 2))
                 }
-                
-                // Country name label (optional - can be hidden at far zoom)
+
                 Text(country.name)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.primary)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(.ultraThinMaterial)
+                    .background(Color.white)
                     .clipShape(Capsule())
             }
             .padding(6)
-            .background(.ultraThinMaterial)
+            .background(Color.white)
             .clipShape(RoundedRectangle(cornerRadius: 24))
             .shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 2)
-            
-            // Pointer/tail
+
             Triangle()
-                .fill(.ultraThinMaterial)
+                .fill(Color.white)
                 .frame(width: 12, height: 6)
-                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+                .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 1)
         }
     }
 }
 
-/// Triangle shape for bubble pointer
 struct Triangle: Shape {
     func path(in rect: CGRect) -> Path {
         var path = Path()
@@ -98,141 +68,131 @@ struct Triangle: Shape {
     }
 }
 
-// MARK: - Full Preview Bubble (Modal/Sheet)
+// MARK: - Full Preview Bubble (Overlay Card)
 
 struct CountryMapPreviewBubble: View {
     let country: Country
     let visit: Visit
     let onDismiss: () -> Void
     let onViewDetails: () -> Void
-    
+
     @State private var appeared = false
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header with country info
+
+            // Header: flag + name + date + close
             HStack(spacing: 12) {
                 Text(country.flagEmoji)
-                    .font(.system(size: 32))
-                
-                VStack(alignment: .leading, spacing: 2) {
+                    .font(.system(size: 36))
+
+                VStack(alignment: .leading, spacing: 3) {
                     Text(country.name)
-                        .font(.headline)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
                         .lineLimit(1)
-                    
-                    if let visitDate = visit.visitedDate {
-                        Text(visitDate, style: .date)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+
+                    if let date = visit.visitedDate {
+                        Text(date.formatted(.dateTime.month(.abbreviated).year()))
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                    } else {
+                        Text(country.continent.displayName)
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
                     }
                 }
-                
+
                 Spacer()
-                
-                Button {
-                    dismiss()
-                } label: {
+
+                Button { animatedDismiss() } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                        .symbolRenderingMode(.hierarchical)
+                        .font(.system(size: 24))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
                 }
                 .buttonStyle(.plain)
             }
-            .padding(12)
-            
-            // Content preview
-            if hasContent {
-                Divider()
-                
-                VStack(alignment: .leading, spacing: 12) {
-                    // Photo preview (if available)
-                    if let firstPhoto = visit.photos.first,
-                       let uiImage = UIImage(data: firstPhoto.imageData) {
-                        Image(uiImage: uiImage)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 120)
-                            .clipped()
-                            .cornerRadius(6)
-                        
-                        if visit.photos.count > 1 {
-                            HStack(spacing: 4) {
-                                Image(systemName: "photo.stack")
-                                    .font(.caption2)
-                                Text("\(visit.photos.count) photos")
-                                    .font(.caption2)
-                            }
-                            .foregroundStyle(.secondary)
-                        }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            .padding(.bottom, hasContent ? 12 : 4)
+
+            // Photo strip
+            if let firstPhoto = visit.photos.first,
+               let uiImage = UIImage(data: firstPhoto.imageData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 130)
+                    .clipped()
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .padding(.horizontal, 16)
+
+                if visit.photos.count > 1 {
+                    HStack(spacing: 4) {
+                        Image(systemName: "photo.stack")
+                            .font(.system(size: 11))
+                        Text("\(visit.photos.count) photos")
+                            .font(.system(size: 12))
                     }
-                    
-                    // Notes preview (if available)
-                    if !visit.notes.isEmpty {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Notes")
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(.secondary)
-                            
-                            Text(visit.notes)
-                                .font(.subheadline)
-                                .foregroundStyle(.primary)
-                                .lineLimit(3)
-                                .multilineTextAlignment(.leading)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    }
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .padding(.horizontal, 16)
+                    .padding(.top, 6)
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 12)
             }
-            
-            // View Details button
+
+            // Notes preview
+            if !visit.notes.isEmpty {
+                Text(visit.notes)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color(hex: "#6B6B6B"))
+                    .lineLimit(2)
+                    .padding(.horizontal, 16)
+                    .padding(.top, hasPhoto ? 10 : 0)
+                    .padding(.bottom, 4)
+            }
+
+            // Divider + View Details row
             Divider()
-            
-            Button {
-                onViewDetails()
-            } label: {
+                .padding(.horizontal, 16)
+                .padding(.top, hasContent ? 12 : 0)
+
+            Button { onViewDetails() } label: {
                 HStack {
                     Text("View Details")
-                        .font(.subheadline.weight(.medium))
-                    
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
                     Spacer()
-                    
                     Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
         }
         .frame(maxWidth: 340)
-        .background(.ultraThinMaterial)
-        .cornerRadius(16)
-        .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 4)
-        .scaleEffect(appeared ? 1.0 : 0.8)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .shadow(color: .black.opacity(0.14), radius: 20, x: 0, y: 6)
+        .scaleEffect(appeared ? 1.0 : 0.88)
         .opacity(appeared ? 1.0 : 0.0)
         .onAppear {
-            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
                 appeared = true
             }
         }
     }
-    
-    private var hasContent: Bool {
-        !visit.photos.isEmpty || !visit.notes.isEmpty
-    }
-    
-    private func dismiss() {
+
+    private var hasPhoto: Bool { !visit.photos.isEmpty }
+    private var hasContent: Bool { !visit.photos.isEmpty || !visit.notes.isEmpty }
+
+    private func animatedDismiss() {
         withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
             appeared = false
         }
-        
-        // Delay actual dismissal to allow animation to complete
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
             onDismiss()
         }
@@ -241,12 +201,11 @@ struct CountryMapPreviewBubble: View {
 
 // MARK: - Preview Container
 
-/// Wrapper to hold country and visit data for preview
 struct CountryPreviewData: Identifiable {
     let id: String
     let country: Country
     let visit: Visit
-    
+
     init(country: Country, visit: Visit) {
         self.id = country.id
         self.country = country

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -12,15 +12,20 @@ import MapKit
 struct MapScreen: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var authService: AuthService
+
+    var onNavigateToStats: () -> Void = {}
+    var onNavigateToCountries: () -> Void = {}
     
     @State private var showSyncStatus = true
     @State private var selectedCountryForSheet: SelectedCountry?
     @State private var selectedCountryForDetail: Country?
     @State private var mapZoomLevel: MapZoomLevel = .continent
     @State private var showingMapUI = true
-    @State private var expandedCountryPreview: CountryPreviewData?
     @State private var filterMode: FilterMode = .all
     @State private var totalCountries: Int = 0
+    @State private var allCountries: [Country] = []
+    @State private var isPopupExpanded = false
+    @State private var showingMemoriesSheet = false
     
     enum FilterMode: String, CaseIterable {
         case all = "All"
@@ -69,172 +74,87 @@ struct MapScreen: View {
                     onCountryTapped: { countryID in
                         handleCountryTap(countryID: countryID)
                     },
-                    onBitmojiTapped: { countryID in
-                        handleBitmojiTap(countryID: countryID)
-                    }
+                    onBitmojiTapped: nil
                 )
-                .edgesIgnoringSafeArea(.top)
-                
-                // Overlay UI Elements - Left side
-                VStack(alignment: .leading, spacing: 12) {
-                    // Stats Card (top left)
-                    if showingMapUI {
-                        statsCard
-                            .transition(.move(edge: .leading).combined(with: .opacity))
-                    }
-                    
-                    Spacer()
-                    
-                    // Legend (bottom left)
-                    if showingMapUI {
-                        legendCard
-                            .padding(.bottom, 80) // Move up to avoid filter bar
-                            .transition(.move(edge: .leading).combined(with: .opacity))
-                    }
-                }
-                .padding()
-                
-                // Filter Picker (bottom center)
-                if showingMapUI {
-                    VStack {
+                .ignoresSafeArea()
+
+                // Full overlay layout
+                VStack(spacing: 0) {
+                    // Top bar: eye button (left) + stats pill (right)
+                    HStack(alignment: .center, spacing: 12) {
+                        eyeButton
                         Spacer()
-                        
-                        filterPicker
-                            .padding(.horizontal, 16)
-                            .padding(.bottom, 20)
+                        if showingMapUI {
+                            statsCard
+                                .transition(.move(edge: .top).combined(with: .opacity))
+                        }
                     }
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                }
-                
-                // Zoom Controls (right side)
-                VStack {
-                    Spacer()
-                    
-                    HStack {
-                        Spacer()
-                        
-                        zoomControls
-                            .padding(.trailing, 16)
-                            .padding(.bottom, showingMapUI ? 100 : 20) // Adjust for filter bar
-                    }
-                }
-                .padding(.top, 100) // Avoid overlap with navigation bar
-                
-                // Sync status indicator (top center)
-                // Keep showing errors even when UI is hidden, but hide success/idle messages
-                if showSyncStatus && (showingMapUI || isSyncError) {
-                    VStack {
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+
+                    // Sync status banner
+                    if showSyncStatus && (showingMapUI || isSyncError) {
                         SyncStatusView(
                             status: appState.syncStatus,
                             onRetry: {
-                                Task {
-                                    await appState.retrySyncIfNeeded()
-                                }
+                                Task { await appState.retrySyncIfNeeded() }
                             },
                             onDismiss: {
-                                withAnimation {
-                                    showSyncStatus = false
-                                }
+                                withAnimation { showSyncStatus = false }
                             }
                         )
-                        .padding(.horizontal)
+                        .padding(.horizontal, 16)
                         .padding(.top, 8)
                         .transition(.move(edge: .top).combined(with: .opacity))
-                        
-                        Spacer()
                     }
-                }
-                
-                // Expanded preview bubble (when tapping a bitmoji)
-                if let preview = expandedCountryPreview {
-                    ZStack {
-                        // Tap outside to dismiss
-                        Color.clear
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                withAnimation {
-                                    expandedCountryPreview = nil
-                                }
-                            }
-                        
-                        VStack {
-                            Spacer()
-                            
-                            HStack {
+
+                    Spacer()
+
+                    // Bottom section
+                    if showingMapUI {
+                        VStack(spacing: 12) {
+                            HStack(alignment: .bottom) {
+                                legendCard
                                 Spacer()
-                                
-                                CountryMapPreviewBubble(
-                                    country: preview.country,
-                                    visit: preview.visit,
-                                    onDismiss: {
-                                        expandedCountryPreview = nil
-                                    },
-                                    onViewDetails: {
-                                        selectedCountryForDetail = preview.country
-                                        expandedCountryPreview = nil
-                                    }
-                                )
-                                
-                                Spacer()
+                                zoomControls
+                                    .fixedSize()
                             }
                             .padding(.horizontal, 16)
-                            .padding(.bottom, 32)
-                            // Prevent tap from passing through to the background
-                            .onTapGesture { }
+
+                            filterPicker
+                                .padding(.horizontal, 16)
                         }
+                        .padding(.bottom, 8)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
                     }
-                    .transition(.opacity)
+
+                    // "Where have you been?" popup — always visible
+                    whereHaveYouBeenPopup
+                        .padding(.bottom, 12)
                 }
+
             }
-            .navigationTitle("Map")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button {
-                        withAnimation(.spring(response: 0.3)) {
-                            showingMapUI.toggle()
-                        }
-                    } label: {
-                        Image(systemName: showingMapUI ? "eye.fill" : "eye.slash.fill")
-                    }
-                }
-                
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    HStack(spacing: 12) {
-                        // Compact sync status in toolbar
-                        SyncStatusToolbarItem(status: appState.syncStatus)
-                        
-                        refreshButton
-                    }
-                }
-            }
+            .toolbar(.hidden, for: .navigationBar)
             .task(id: authService.user?.uid) {
                 await handleAuthStateChange()
             }
             .onChange(of: appState.syncStatus) { oldValue, newValue in
-                // Show status banner when status changes
                 if case .idle = oldValue, case .idle = newValue {
-                    // Don't show for idle -> idle
                 } else {
-                    withAnimation {
-                        showSyncStatus = true
-                    }
-                    
-                    // Auto-hide success message after 3 seconds
+                    withAnimation { showSyncStatus = true }
                     if case .success = newValue {
                         Task {
                             try? await Task.sleep(for: .seconds(3))
-                            withAnimation {
-                                showSyncStatus = false
-                            }
+                            withAnimation { showSyncStatus = false }
                         }
                     }
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-                Task {
-                    await refreshMapData()
-                }
+                Task { await refreshMapData() }
+            }
+            .sheet(isPresented: $showingMemoriesSheet) {
+                MapMemoriesSheet(visits: appState.visits, countries: allCountries)
             }
             .sheet(item: $selectedCountryForSheet) { selectedCountry in
                 CountryQuickActionSheet(
@@ -252,54 +172,67 @@ struct MapScreen: View {
                 CountryDetailScreen(country: country)
             }
             .task {
-                // Load total countries count from CountryDataService
                 let countries = CountryDataService.shared.loadCountries()
                 totalCountries = countries.count
+                allCountries = countries
             }
         }
     }
     
+    // MARK: - Eye Button
+
+    private var eyeButton: some View {
+        Button {
+            withAnimation(.spring(response: 0.3)) {
+                showingMapUI.toggle()
+            }
+        } label: {
+            Image(systemName: showingMapUI ? "eye" : "eye.slash")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Color.black)
+                .frame(width: 40, height: 40)
+                .background(Color.white)
+                .clipShape(Circle())
+                .shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 3)
+        }
+        .buttonStyle(.plain)
+    }
+
     // MARK: - Zoom Controls
-    
+
     private var zoomControls: some View {
-        VStack(spacing: 1) {
-            // Zoom In Button
+        VStack(spacing: 0) {
             Button {
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-                    zoomIn()
-                }
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) { zoomIn() }
             } label: {
                 Image(systemName: "plus")
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .frame(width: 44, height: 44)
-                    .background(.ultraThinMaterial)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(canZoomIn ? Color.black : Color.black.opacity(0.3))
+                    .frame(width: 40, height: 36)
                     .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
             .disabled(!canZoomIn)
-            .opacity(canZoomIn ? 1 : 0.5)
-            
-            Divider()
-                .frame(width: 44)
-            
-            // Zoom Out Button
+
+            Rectangle()
+                .fill(Color(hex: "#EEEEEE"))
+                .frame(width: 28, height: 1)
+
             Button {
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-                    zoomOut()
-                }
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) { zoomOut() }
             } label: {
                 Image(systemName: "minus")
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundStyle(.primary)
-                    .frame(width: 44, height: 44)
-                    .background(.ultraThinMaterial)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(canZoomOut ? Color.black : Color.black.opacity(0.3))
+                    .frame(width: 40, height: 36)
                     .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
             .disabled(!canZoomOut)
-            .opacity(canZoomOut ? 1 : 0.5)
         }
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 3)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 3)
     }
     
     private var canZoomIn: Bool {
@@ -349,139 +282,314 @@ struct MapScreen: View {
     }
     
     // MARK: - Filter Picker
-    
+
     private var filterPicker: some View {
-        Picker("Filter", selection: $filterMode) {
+        HStack(spacing: 8) {
+            Spacer()
             ForEach(FilterMode.allCases, id: \.self) { mode in
-                Text(mode.rawValue).tag(mode)
+                Button {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        filterMode = mode
+                    }
+                } label: {
+                    Text(mode.rawValue)
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(filterMode == mode ? Color.white : Color.black)
+                        .padding(.horizontal, 22)
+                        .padding(.vertical, 10)
+                        .background(filterMode == mode ? Color.black : Color.white)
+                        .clipShape(Capsule())
+                        .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+                }
+                .buttonStyle(.plain)
             }
+            Spacer()
         }
-        .pickerStyle(.segmented)
-        .padding(8)
-        .background(.ultraThinMaterial)
-        .cornerRadius(12)
-        .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
     }
     
     // MARK: - Stats Card
-    
+
     private var statsCard: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Image(systemName: "globe.americas.fill")
-                    .foregroundStyle(.blue)
-                Text("Countries Visited")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        HStack(spacing: 10) {
+            HStack(spacing: 4) {
+                Image(systemName: "globe")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                Text("VISITED")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .tracking(0.5)
             }
-            
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
+
+            Rectangle()
+                .fill(Color(hex: "#E0E0E0"))
+                .frame(width: 1, height: 16)
+
+            HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text("\(appState.visitedCountryIDs.count)")
-                    .font(.title.bold())
-                    .foregroundStyle(.primary)
+                    .font(.system(size: 20, weight: .black))
+                    .foregroundStyle(Color.black)
                 Text("/ \(totalCountries)")
-                    .font(.body)
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
             }
-            
-            if appState.visitedCountryIDs.count > 0 && totalCountries > 0 {
-                let percentage = Double(appState.visitedCountryIDs.count) / Double(totalCountries) * 100
-                Text("\(percentage, specifier: "%.1f")% of the world")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+
+            if totalCountries > 0 {
+                Rectangle()
+                    .fill(Color(hex: "#E0E0E0"))
+                    .frame(width: 1, height: 16)
+
+                let pct = Double(appState.visitedCountryIDs.count) / Double(totalCountries) * 100
+                Text(String(format: "%.1f%% WORLD", pct))
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .tracking(0.5)
             }
         }
-        .padding(12)
-        .background(.ultraThinMaterial)
-        .cornerRadius(12)
-        .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+        .padding(.vertical, 10)
+        .padding(.horizontal, 14)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+        .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 3)
     }
     
     // MARK: - Legend Card
-    
+
     private var legendCard: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Legend")
-                .font(.caption.bold())
-                .foregroundStyle(.primary)
-            
-            if filterMode == .all || filterMode == .visited {
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(Color.green)
-                        .frame(width: 12, height: 12)
-                    Text("Visited")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 10) {
+            Text("MAP LEGEND")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(Color(hex: "#9E9E9E"))
+                .tracking(1.2)
+
+            VStack(alignment: .leading, spacing: 8) {
+                if filterMode == .all || filterMode == .visited {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(Color(hex: "#F9234D"))
+                            .frame(width: 10, height: 10)
+                        Text("VISITED")
+                            .font(.system(size: 10, weight: .black))
+                            .foregroundStyle(Color.black)
+                            .tracking(0.5)
+                    }
                 }
-            }
-            
-            if filterMode == .all || filterMode == .wishlist {
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(Color.orange)
-                        .frame(width: 12, height: 12)
-                    Text("Wishlist")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            
-            if filterMode == .all {
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(Color.gray.opacity(0.6))
-                        .frame(width: 12, height: 12)
-                    Text("Not visited")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+
+                if filterMode == .all || filterMode == .wishlist {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(Color(hex: "#93E0FA"))
+                            .frame(width: 10, height: 10)
+                        Text("WISHLIST")
+                            .font(.system(size: 10, weight: .black))
+                            .foregroundStyle(Color.black)
+                            .tracking(0.5)
+                    }
                 }
             }
         }
-        .padding(12)
+        .padding(14)
+        .background(Color.white.opacity(0.9))
         .background(.ultraThinMaterial)
-        .cornerRadius(12)
-        .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.12), radius: 8, x: 0, y: 4)
     }
     
-    // MARK: - Refresh Button
-    
-    private var refreshButton: some View {
-        Button {
-            Task {
-                await refreshMapData()
-            }
-        } label: {
-            Image(systemName: "arrow.clockwise")
+    // MARK: - Where Have You Been Popup
+
+    private var recentVisits: [(country: Country, visit: Visit)] {
+        allCountries.compactMap { country in
+            guard let visit = appState.visits[country.id], visit.isVisited else { return nil }
+            return (country, visit)
         }
-        .disabled(appState.isSyncing || !authService.isSignedIn)
+        .sorted {
+            let a = $0.visit.visitedDate ?? $0.visit.updatedAt
+            let b = $1.visit.visitedDate ?? $1.visit.updatedAt
+            return a > b
+        }
+        .prefix(3)
+        .map { $0 }
     }
-    
+
+    private func visitSubtitle(_ visit: Visit) -> String {
+        let notes = visit.notes.trimmingCharacters(in: .whitespaces)
+        if let date = visit.visitedDate {
+            let formatted = date.formatted(.dateTime.month(.abbreviated).year())
+            return notes.isEmpty ? formatted : "\(notes) · \(formatted)"
+        }
+        return notes.isEmpty ? "" : notes
+    }
+
+    private var whereHaveYouBeenPopup: some View {
+        VStack(spacing: 0) {
+
+            // MARK: Drag handle — always visible, toggles on tap/swipe
+            VStack(spacing: 0) {
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(Color(hex: "#CCCCCC"))
+                    .frame(width: 36, height: 5)
+                    .padding(.top, 14)
+                    .padding(.bottom, 16)
+
+                HStack {
+                    Text("Where have you been?")
+                        .font(.system(size: 26, weight: .bold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                    Spacer()
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, isPopupExpanded ? 20 : 18)
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                    isPopupExpanded.toggle()
+                }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 20)
+                    .onEnded { value in
+                        let dy = value.translation.height
+                        if dy < -30 && !isPopupExpanded {
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) { isPopupExpanded = true }
+                        } else if dy > 30 && isPopupExpanded {
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) { isPopupExpanded = false }
+                        }
+                    }
+            )
+
+            // MARK: Expanded content
+            if isPopupExpanded {
+
+                // Quick action buttons (Memories + Stats)
+                HStack(spacing: 12) {
+                    quickActionButton(icon: "photo.stack.fill", label: "Memories") {
+                        showingMemoriesSheet = true
+                    }
+                    quickActionButton(icon: "chart.bar.fill", label: "Stats") {
+                        onNavigateToStats()
+                        withAnimation(.spring(response: 0.3)) { isPopupExpanded = false }
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 20)
+
+                // Recent visits header
+                HStack {
+                    Text("Recent visits")
+                        .font(.system(size: 17, weight: .bold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                    Spacer()
+                    Button {
+                        onNavigateToCountries()
+                        withAnimation(.spring(response: 0.3)) { isPopupExpanded = false }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text("See all")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 12)
+
+                // Recent visits list
+                let recent = recentVisits
+                if recent.isEmpty {
+                    Text("Mark countries as visited to see them here")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 20)
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(recent, id: \.country.id) { item in
+                            Button {
+                                selectedCountryForDetail = item.country
+                                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                                    isPopupExpanded = false
+                                }
+                            } label: {
+                                HStack(spacing: 14) {
+                                    ZStack {
+                                        Circle()
+                                            .fill(Color(hex: "#F3F3F3"))
+                                            .frame(width: 48, height: 48)
+                                        Text(item.country.flagEmoji)
+                                            .font(.system(size: 24))
+                                    }
+
+                                    VStack(alignment: .leading, spacing: 3) {
+                                        Text(item.country.name)
+                                            .font(.system(size: 15, weight: .semibold))
+                                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                                        let subtitle = visitSubtitle(item.visit)
+                                        if !subtitle.isEmpty {
+                                            Text(subtitle)
+                                                .font(.system(size: 13))
+                                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                                        }
+                                    }
+
+                                    Spacer()
+
+                                    Image(systemName: "chevron.right")
+                                        .font(.system(size: 12, weight: .semibold))
+                                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                                }
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 14)
+                            }
+                            .buttonStyle(.plain)
+
+                            if item.country.id != recent.last?.country.id {
+                                Divider().padding(.horizontal, 20)
+                            }
+                        }
+                    }
+                    .padding(.bottom, 8)
+                }
+            }
+        }
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+        .shadow(color: .black.opacity(0.12), radius: 16, x: 0, y: -4)
+        .padding(.horizontal, 16)
+    }
+
+    private func quickActionButton(icon: String, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 10) {
+                ZStack {
+                    Circle()
+                        .fill(Color(hex: "#1b1b1b"))
+                        .frame(width: 44, height: 44)
+                    Image(systemName: icon)
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundStyle(.white)
+                }
+                Text(label)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 100)
+            .background(Color(hex: "#F3F3F3"))
+            .clipShape(RoundedRectangle(cornerRadius: 18))
+        }
+        .buttonStyle(.plain)
+    }
+
     // MARK: - Data Management
     
     private func handleCountryTap(countryID: String) {
-        // Close any expanded preview first
-        expandedCountryPreview = nil
-        
-        // Always show quick action sheet (for both visited and unvisited)
         selectedCountryForSheet = SelectedCountry(id: countryID)
-    }
-    
-    private func handleBitmojiTap(countryID: String) {
-        // Close any open quick action sheet first
-        selectedCountryForSheet = nil
-        
-        // Show expanded preview when tapping a bitmoji
-        let countries = CountryDataService.shared.loadCountries()
-        guard let country = countries.first(where: { $0.id == countryID }) else {
-            return
-        }
-        
-        let visit = appState.visit(for: countryID)
-        
-        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-            expandedCountryPreview = CountryPreviewData(country: country, visit: visit)
-        }
     }
     
     private func getBitmojiAnnotations() -> [CountryBitmojiAnnotation] {
@@ -566,171 +674,159 @@ struct CountryQuickActionSheet: View {
     @ObservedObject var appState: AppState
     let onViewDetails: (Country) -> Void
     @Environment(\.dismiss) private var dismiss
-    
+
     @State private var country: Country?
     @State private var isLoading = true
-    
-    private var isVisited: Bool {
-        appState.isVisited(countryID)
-    }
-    
-    private var wantToVisit: Bool {
-        appState.wantToVisit(countryID)
-    }
-    
+
+    private var isVisited: Bool { appState.isVisited(countryID) }
+    private var wantToVisit: Bool { appState.wantToVisit(countryID) }
+
     var body: some View {
         VStack(spacing: 0) {
-            // Header
-            if isLoading {
-                VStack(spacing: 12) {
-                    ProgressView()
-                    Text("Loading...")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.vertical, 40)
-            } else if let country = country {
-                VStack(spacing: 12) {
-                    Text(country.flagEmoji)
-                        .font(.system(size: 64))
-                    
-                    Text(country.name)
-                        .font(.title2.bold())
-                    
-                    Text(country.continent.displayName)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.top, 24)
+            // Drag handle
+            RoundedRectangle(cornerRadius: 2.5)
+                .fill(Color(hex: "#CCCCCC"))
+                .frame(width: 36, height: 5)
+                .padding(.top, 12)
                 .padding(.bottom, 20)
+
+            if isLoading {
+                Spacer()
+                ProgressView()
+                Spacer()
+            } else if let country = country {
+                // Country hero
+                VStack(spacing: 10) {
+                    Text(country.flagEmoji)
+                        .font(.system(size: 60))
+
+                    Text(country.name)
+                        .font(.system(size: 22, weight: .bold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
+
+                    HStack(spacing: 8) {
+                        Text(country.continent.displayName)
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+
+                        if isVisited {
+                            statusPill("Visited", fg: Color(hex: "#2E9E5B"), bg: Color(hex: "#F0FFF4"))
+                        } else if wantToVisit {
+                            statusPill("Wishlist", fg: Color(hex: "#1D8FC2"), bg: Color(hex: "#EAF6FE"))
+                        }
+                    }
+                }
+                .padding(.bottom, 24)
+
+                // Action card
+                VStack(spacing: 0) {
+                    actionRow(
+                        icon: "checkmark.circle.fill",
+                        iconBg: isVisited ? Color(hex: "#F0FFF4") : Color(hex: "#F3F3F3"),
+                        iconFg: isVisited ? Color(hex: "#2E9E5B") : Color(hex: "#9E9E9E"),
+                        title: isVisited ? "Mark as Not Visited" : "Mark as Visited",
+                        chevron: false,
+                        disabled: false
+                    ) { toggleVisited() }
+
+                    Divider().padding(.horizontal, 16)
+
+                    actionRow(
+                        icon: wantToVisit ? "star.fill" : "star",
+                        iconBg: wantToVisit ? Color(hex: "#EAF6FE") : Color(hex: "#F3F3F3"),
+                        iconFg: wantToVisit ? Color(hex: "#4A90D9") : Color(hex: "#9E9E9E"),
+                        title: wantToVisit ? "Remove from Wishlist" : "Add to Wishlist",
+                        chevron: false,
+                        disabled: isVisited
+                    ) { toggleWantToVisit() }
+
+                    Divider().padding(.horizontal, 16)
+
+                    actionRow(
+                        icon: "arrow.right.circle.fill",
+                        iconBg: Color(hex: "#EAF4FF"),
+                        iconFg: Color(hex: "#4A90D9"),
+                        title: "View Details",
+                        chevron: true,
+                        disabled: false
+                    ) { onViewDetails(country) }
+                }
+                .background(Color.white)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+                .padding(.horizontal, 16)
+
+                Spacer()
             } else {
-                VStack(spacing: 12) {
+                Spacer()
+                VStack(spacing: 10) {
                     Image(systemName: "exclamationmark.triangle")
-                        .font(.largeTitle)
-                        .foregroundStyle(.orange)
+                        .font(.system(size: 36))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
                     Text("Country not found")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .font(.system(size: 15))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
                 }
-                .padding(.vertical, 40)
+                Spacer()
             }
-            
-            Divider()
-            
-            // Actions
-            VStack(spacing: 0) {
-                Button {
-                    toggleVisited()
-                } label: {
-                    HStack {
-                        Image(systemName: isVisited ? "checkmark.circle.fill" : "checkmark.circle")
-                            .font(.title3)
-                            .foregroundStyle(isVisited ? .green : .gray)
-                        
-                        Text(isVisited ? "Mark as Not Visited" : "Mark as Visited")
-                            .font(.headline)
-                        
-                        Spacer()
-                    }
-                    .padding()
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(country == nil)
-                
-                Divider()
-                    .padding(.leading)
-                
-                Button {
-                    toggleWantToVisit()
-                } label: {
-                    HStack {
-                        Image(systemName: wantToVisit ? "star.fill" : "star")
-                            .font(.title3)
-                            .foregroundStyle(wantToVisit ? .orange : .gray)
-                        
-                        Text(wantToVisit ? "Remove from Wishlist" : "Want to Visit")
-                            .font(.headline)
-                        
-                        Spacer()
-                    }
-                    .padding()
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(isVisited || country == nil)
-                
-                Divider()
-                    .padding(.leading)
-                
-                Button {
-                    if let country = country {
-                        onViewDetails(country)
-                    }
-                } label: {
-                    HStack {
-                        Image(systemName: "info.circle")
-                            .font(.title3)
-                            .foregroundStyle(.blue)
-                        
-                        Text("View Details")
-                            .font(.headline)
-                        
-                        Spacer()
-                        
-                        Image(systemName: "chevron.right")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding()
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(country == nil)
-            }
-            
-            Spacer()
         }
-        .task {
-            await loadCountry()
-        }
+        .background(Color(hex: "#F7F7F7"))
+        .task { await loadCountry() }
     }
-    
+
+    private func statusPill(_ label: String, fg: Color, bg: Color) -> some View {
+        Text(label)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(fg)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(bg)
+            .clipShape(Capsule())
+    }
+
+    private func actionRow(icon: String, iconBg: Color, iconFg: Color, title: String, chevron: Bool, disabled: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                ZStack {
+                    Circle().fill(iconBg).frame(width: 40, height: 40)
+                    Image(systemName: icon)
+                        .font(.system(size: 16))
+                        .foregroundStyle(iconFg)
+                }
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(disabled ? Color(hex: "#CCCCCC") : Color(hex: "#1b1b1b"))
+                Spacer()
+                if chevron {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled || country == nil)
+    }
+
     private func loadCountry() async {
-        // Load countries (happens on main actor)
         let countries = CountryDataService.shared.loadCountries()
-        
-        // Find matching country
         country = countries.first { $0.id == countryID }
         isLoading = false
     }
-    
+
     private func toggleVisited() {
-        let newState = !isVisited
-        appState.setVisited(countryID, isVisited: newState)
-        
-        // Provide haptic feedback
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
-        
-        // Dismiss after a short delay to show the state change
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            dismiss()
-        }
+        appState.setVisited(countryID, isVisited: !isVisited)
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { dismiss() }
     }
-    
+
     private func toggleWantToVisit() {
-        let newState = !wantToVisit
-        appState.setWantToVisit(countryID, wantToVisit: newState)
-        
-        // Provide haptic feedback
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
-        
-        // Dismiss after a short delay to show the state change
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            dismiss()
-        }
+        appState.setWantToVisit(countryID, wantToVisit: !wantToVisit)
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { dismiss() }
     }
 }
 
@@ -753,6 +849,111 @@ struct MapContainerView: View {
             bitmojiAnnotations: bitmojiAnnotations,
             onBitmojiTapped: onBitmojiTapped
         )
+    }
+}
+
+// MARK: - Memories Sheet
+
+struct MapMemoriesSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let visits: [String: Visit]
+    let countries: [Country]
+
+    private struct PhotoEntry: Identifiable {
+        let id: UUID
+        let photo: VisitPhoto
+        let country: Country
+    }
+
+    private var allPhotos: [PhotoEntry] {
+        countries.flatMap { country -> [PhotoEntry] in
+            guard let visit = visits[country.id], visit.isVisited else { return [] }
+            return visit.photos.map { PhotoEntry(id: $0.id, photo: $0, country: country) }
+        }
+        .sorted { $0.photo.createdAt > $1.photo.createdAt }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Memories")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                Spacer()
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 26))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 16)
+
+            if allPhotos.isEmpty {
+                Spacer()
+                VStack(spacing: 12) {
+                    Image(systemName: "photo.stack")
+                        .font(.system(size: 48))
+                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                    Text("No memories yet")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                    Text("Add photos when marking countries\nas visited to see them here")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .multilineTextAlignment(.center)
+                }
+                Spacer()
+            } else {
+                ScrollView {
+                    LazyVGrid(
+                        columns: [GridItem(.flexible(), spacing: 3), GridItem(.flexible(), spacing: 3)],
+                        spacing: 3
+                    ) {
+                        ForEach(allPhotos) { entry in
+                            GeometryReader { geo in
+                                ZStack(alignment: .bottomLeading) {
+                                    if let uiImage = UIImage(data: entry.photo.imageData) {
+                                        Image(uiImage: uiImage)
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: geo.size.width, height: geo.size.width)
+                                            .clipped()
+                                    } else {
+                                        Rectangle()
+                                            .fill(Color(hex: "#F3F3F3"))
+                                            .frame(width: geo.size.width, height: geo.size.width)
+                                    }
+
+                                    LinearGradient(
+                                        colors: [.clear, .black.opacity(0.55)],
+                                        startPoint: .center,
+                                        endPoint: .bottom
+                                    )
+
+                                    HStack(spacing: 4) {
+                                        Text(entry.country.flagEmoji)
+                                            .font(.system(size: 13))
+                                        Text(entry.country.name)
+                                            .font(.system(size: 11, weight: .semibold))
+                                            .foregroundStyle(.white)
+                                            .lineLimit(1)
+                                    }
+                                    .padding(.horizontal, 8)
+                                    .padding(.bottom, 8)
+                                }
+                            }
+                            .aspectRatio(1, contentMode: .fill)
+                        }
+                    }
+                    .padding(.bottom, 20)
+                }
+            }
+        }
+        .background(Color(hex: "#F7F7F7"))
     }
 }
 

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
@@ -372,17 +372,14 @@ struct VisitedCountriesMapView: UIViewRepresentable {
             let countryID = countryID(for: overlay)
 
             if let countryID, visitedCountryIDs.contains(countryID) {
-                // Priority 1: Visited countries - vibrant green
-                renderer.fillColor = UIColor.systemGreen.withAlphaComponent(0.7)
-                renderer.strokeColor = UIColor.systemGreen.withAlphaComponent(0.9)
+                renderer.fillColor = UIColor(red: 0.976, green: 0.137, blue: 0.302, alpha: 0.7)
+                renderer.strokeColor = UIColor(red: 0.976, green: 0.137, blue: 0.302, alpha: 0.9)
                 renderer.lineWidth = 1.5
             } else if let countryID, wantToVisitCountryIDs.contains(countryID) {
-                // Priority 2: Want to Visit countries - warm orange
-                renderer.fillColor = UIColor.systemOrange.withAlphaComponent(0.6)
-                renderer.strokeColor = UIColor.systemOrange.withAlphaComponent(0.8)
+                renderer.fillColor = UIColor(red: 0.576, green: 0.878, blue: 0.980, alpha: 0.7)
+                renderer.strokeColor = UIColor(red: 0.576, green: 0.878, blue: 0.980, alpha: 0.9)
                 renderer.lineWidth = 1.2
             } else {
-                // Priority 3: Unvisited countries - neutral gray
                 renderer.fillColor = UIColor.systemGray5.withAlphaComponent(0.85)
                 renderer.strokeColor = UIColor.systemGray3.withAlphaComponent(0.7)
                 renderer.lineWidth = 0.5

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
@@ -11,10 +11,10 @@ import FirebaseAuth
 struct RootTabView: View {
     @EnvironmentObject private var authService: AuthService
     @EnvironmentObject private var appState: AppState
-    
+
     // Track selected tab - always starts on Map when view is created
     @State private var selectedTab: Tab = .map
-    
+
     enum Tab {
         case map
         case countries
@@ -25,12 +25,15 @@ struct RootTabView: View {
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            MapScreen()
-                .tabItem {
-                    Label("Map", systemImage: "map")
-                }
-                .tag(Tab.map)
-            
+            MapScreen(
+                onNavigateToStats: { selectedTab = .stats },
+                onNavigateToCountries: { selectedTab = .countries }
+            )
+            .tabItem {
+                Label("Map", systemImage: "map")
+            }
+            .tag(Tab.map)
+
             CountriesScreen()
                 .tabItem {
                     Label("Countries", systemImage: "list.bullet")
@@ -42,7 +45,7 @@ struct RootTabView: View {
                     Label("Stats", systemImage: "chart.bar")
                 }
                 .tag(Tab.stats)
-            
+
             // Travel Comparison
             ComparisonView()
                 .tabItem {
@@ -61,10 +64,10 @@ struct RootTabView: View {
             // Ensure tab bar is always visible and properly styled
             let appearance = UITabBarAppearance()
             appearance.configureWithDefaultBackground()
-            
+
             UITabBar.appearance().standardAppearance = appearance
             UITabBar.appearance().scrollEdgeAppearance = appearance
-            
+
             #if DEBUG
             print("🗺️ RootTabView appeared with signInCounter=\(authService.signInCounter), selectedTab=\(selectedTab)")
             #endif

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
@@ -11,36 +11,21 @@ import Combine
 struct StatsScreen: View {
     @EnvironmentObject private var appState: AppState
     @StateObject private var vm = StatsViewModel()
-    
-    init() {
-        #if DEBUG
-        print("🎨 StatsScreen initialized")
-        #endif
-    }
-    
-    // MARK: - Computed stats
-    
+    @State private var selectedAchievement: Achievement?
+
+    // MARK: - Computed properties
+
     private var visitedVisits: [Visit] {
-        appState.visits.values
-            .filter { $0.isVisited }
+        appState.visits.values.filter { $0.isVisited }
     }
-    
+
     private var wantToVisitVisits: [Visit] {
-        appState.visits.values
-            .filter { $0.wantToVisit }
+        appState.visits.values.filter { $0.wantToVisit }
     }
-    
-    private var totalCountriesCount: Int {
-        vm.countries.count
-    }
-    
-    private var visitedCountriesCount: Int {
-        visitedVisits.count
-    }
-    
-    private var wantToVisitCount: Int {
-        wantToVisitVisits.count
-    }
+
+    private var totalCountriesCount: Int { vm.countries.count }
+    private var visitedCountriesCount: Int { visitedVisits.count }
+    private var wantToVisitCount: Int { wantToVisitVisits.count }
 
     private var totalPhotosCount: Int {
         visitedVisits.reduce(0) { $0 + $1.photos.count }
@@ -49,698 +34,594 @@ struct StatsScreen: View {
     private var currentYear: Int {
         Calendar.current.component(.year, from: Date())
     }
-    
+
     private var visitedPercentage: Double {
         guard totalCountriesCount > 0 else { return 0 }
         return Double(visitedCountriesCount) / Double(totalCountriesCount) * 100
     }
-    
+
     private var achievements: [Achievement] {
         vm.achievements(from: appState.visits)
     }
-    
-    private var achievementSummary: (total: Int, unlocked: Int) {
-        AchievementEngine.achievementSummary(achievements)
-    }
-    
+
     private var visitedCountries: [Country] {
-        let visitedIDs = Set(visitedVisits.map { $0.countryId })
-        return vm.countries.filter { visitedIDs.contains($0.id) }
+        let ids = Set(visitedVisits.map { $0.countryId })
+        return vm.countries.filter { ids.contains($0.id) }
     }
-    
+
     private var wantToVisitCountries: [Country] {
-        let wantToVisitIDs = Set(wantToVisitVisits.map { $0.countryId })
-        return vm.countries.filter { wantToVisitIDs.contains($0.id) }
+        let ids = Set(wantToVisitVisits.map { $0.countryId })
+        return vm.countries.filter { ids.contains($0.id) }
     }
-    
+
     private var visitedThisYear: [(country: Country, date: Date)] {
         let calendar = Calendar.current
-        let currentYear = calendar.component(.year, from: Date())
+        let year = calendar.component(.year, from: Date())
         let byId = Dictionary(uniqueKeysWithValues: vm.countries.map { ($0.id, $0) })
-        
         return visitedVisits
             .compactMap { visit -> (country: Country, date: Date)? in
-                // Get country first
-                guard let country = byId[visit.countryId] else {
-                    return nil
-                }
-                
-                // For visited countries, use visitedDate (should always exist for visited)
-                // If somehow missing, fall back to updatedAt to avoid losing the data
-                guard let date = visit.visitedDate ?? (visit.isVisited ? visit.updatedAt : nil) else {
-                    return nil
-                }
-                
-                // Check if the date is in the current year
-                guard calendar.component(.year, from: date) == currentYear else {
-                    return nil
-                }
-                
+                guard let country = byId[visit.countryId] else { return nil }
+                guard let date = visit.visitedDate ?? (visit.isVisited ? visit.updatedAt : nil) else { return nil }
+                guard calendar.component(.year, from: date) == year else { return nil }
                 return (country: country, date: date)
             }
             .sorted { $0.date > $1.date }
     }
-    
-    private var visitedByContinent: [(continent: Continent, visited: Int, wantToVisit: Int, total: Int, percentage: Double)] {
+
+    private var visitedByContinent: [(continent: Continent, visited: Int, total: Int, percentage: Double)] {
         let grouped = Dictionary(grouping: vm.countries, by: { $0.continent })
-        
-        return Continent.allCases.map { continent in
+        let visitedIDs = Set(visitedVisits.map { $0.countryId })
+        return Continent.allCases.compactMap { continent in
             let all = grouped[continent] ?? []
-            let visitedIDs = Set(visitedVisits.map { $0.countryId })
-            let wantToVisitIDs = Set(wantToVisitVisits.map { $0.countryId })
+            guard !all.isEmpty else { return nil }
             let visited = all.filter { visitedIDs.contains($0.id) }.count
-            let wantToVisit = all.filter { wantToVisitIDs.contains($0.id) }.count
-            let percentage = all.count > 0 ? Double(visited) / Double(all.count) * 100 : 0
-            return (continent: continent, visited: visited, wantToVisit: wantToVisit, total: all.count, percentage: percentage)
+            let pct = Double(visited) / Double(all.count) * 100
+            return (continent: continent, visited: visited, total: all.count, percentage: pct)
         }
-        .filter { $0.total > 0 }
         .sorted { $0.percentage > $1.percentage }
     }
-    
+
     private var recentVisits: [(country: Country, date: Date?)] {
         let byId = Dictionary(uniqueKeysWithValues: vm.countries.map { ($0.id, $0) })
-        
         return visitedVisits
             .compactMap { visit in
                 guard let country = byId[visit.countryId] else { return nil }
                 return (country: country, date: visit.visitedDate)
             }
             .sorted {
-                // visits with date first, newest first
                 switch ($0.date, $1.date) {
-                case let (d0?, d1?):
-                    return d0 > d1
-                case (nil, _?):
-                    return false
-                case (_?, nil):
-                    return true
-                case (nil, nil):
-                    return $0.country.name < $1.country.name
+                case let (d0?, d1?): return d0 > d1
+                case (nil, _?): return false
+                case (_?, nil): return true
+                case (nil, nil): return $0.country.name < $1.country.name
                 }
             }
     }
-    
-    // MARK: - Design system views
 
-    private var continentsVisitedCount: Int {
-        visitedByContinent.filter { $0.visited > 0 }.count
-    }
-
-    private var statsHeader: some View {
-        ZStack(alignment: .topLeading) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Your journey").eyebrowStyle()
-                HStack(spacing: 0) {
-                    Text("The ")
-                        .font(.system(size: 44, weight: .regular, design: .serif))
-                        .foregroundStyle(Color.appInk)
-                    Text("numbers")
-                        .font(AppTypography.displayLarge)
-                        .foregroundStyle(Color.appSky)
-                }
-            }
-
-            // Confetti decorations
-            Circle().fill(Color.appRose).frame(width: 9, height: 9)
-                .offset(x: 212, y: 8)
-            Text("▶")
-                .font(.system(size: 11, weight: .bold)).foregroundStyle(Color.appLime)
-                .offset(x: 178, y: 52)
-            Text("★")
-                .font(.system(size: 18)).foregroundStyle(Color.appSunset)
-                .offset(x: 228, y: 60)
-            ConfettiWave()
-                .stroke(Color.appRose, style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
-                .frame(width: 28, height: 20)
-                .offset(x: 244, y: 22)
-            Text("◀")
-                .font(.system(size: 13, weight: .bold)).foregroundStyle(Color.appInk)
-                .offset(x: 272, y: 74)
-            Text("★")
-                .font(.system(size: 12)).foregroundStyle(Color.appLime)
-                .offset(x: 213, y: 108)
-        }
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-    }
-
-    private var heroCard: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("You've explored")
-                .font(AppTypography.eyebrow)
-                .fontWeight(.bold)
-                .tracking(2.0)
-                .textCase(.uppercase)
-                .foregroundStyle(Color.white.opacity(0.82))
-                .padding(.bottom, 6)
-
-            HStack(alignment: .firstTextBaseline, spacing: 10) {
-                Text("\(visitedCountriesCount)")
-                    .font(AppTypography.displayHero)
-                    .foregroundStyle(Color.white)
-
-                Text("of \(totalCountriesCount)")
-                    .font(.system(size: 17, weight: .medium))
-                    .foregroundStyle(Color.white.opacity(0.85))
-            }
-            .padding(.bottom, 8)
-
-            Text("\(visitedPercentage, specifier: "%.1f")% of the world · \(continentsVisitedCount) continents")
-                .font(AppTypography.bodySmall)
-                .fontWeight(.medium)
-                .foregroundStyle(Color.white.opacity(0.9))
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(18)
-        .background(
-            ZStack(alignment: .bottomTrailing) {
-                Color.appRose
-                Text("\(Int(visitedPercentage))%")
-                    .font(AppTypography.displayHero)
-                    .italic()
-                    .foregroundStyle(Color.white.opacity(0.09))
-                    .padding(.trailing, -12)
-                    .padding(.bottom, -28)
-            }
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 26))
-        .shadow(color: Color.appRose.opacity(0.32), radius: 28, x: 0, y: 10)
-    }
-
-    // MARK: - UI
+    // MARK: - Body
 
     var body: some View {
         NavigationStack {
-            ZStack {
-                List {
-                    // MARK: - Stats Header + Hero Card + Mini Stats
-                    Section {
-                        VStack(alignment: .leading, spacing: 4) {
-                            statsHeader
-                                .padding(.horizontal, 16)
-                            heroCard
-                                .padding(.horizontal, 16)
-                                .padding(.bottom, 14)
-                            HStack(spacing: 10) {
-                                MiniStatCard(
-                                    value: "\(visitedThisYear.count)",
-                                    label: "in \(currentYear)",
-                                    background: Color.appLime,
-                                    foreground: Color.appInk
-                                )
-                                MiniStatCard(
-                                    value: "\(wantToVisitCount)",
-                                    label: "on wishlist",
-                                    background: Color.appAqua,
-                                    foreground: Color.appInk
-                                )
-                                MiniStatCard(
-                                    value: "\(totalPhotosCount)",
-                                    label: "photos",
-                                    background: Color.appSunset,
-                                    foreground: .white
-                                )
-                            }
-                            .padding(.horizontal, 16)
-                        }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    overviewSection
+                        .padding(.horizontal, 16)
+                        .padding(.top, 20)
+
+                    summarySection
+                        .padding(.horizontal, 16)
                         .padding(.top, 24)
-                        .listRowBackground(Color.appPaper)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-                    }
-                    
-                    // MARK: - Badges
-                    Section {
-                        Text("Badges").eyebrowStyle()
-                            .padding(.horizontal, 16)
-                            .padding(.top, 8)
-                            .listRowBackground(Color.appPaper)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets())
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 10) {
-                                ForEach(achievements) { achievement in
-                                    AchievementCard(achievement: achievement)
-                                }
-                            }
-                            .padding(.vertical, 6)
-                            .padding(.horizontal, 16)
-                        }
-                        .listRowBackground(Color.appPaper)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 4, trailing: 0))
-                    }
 
-                    // MARK: - Travel Wishlist
                     if !wantToVisitCountries.isEmpty {
-                        Section {
-                            Text("Travel Wishlist").eyebrowStyle()
-                                .padding(.horizontal, 16)
-                                .padding(.top, 8)
-                                .listRowBackground(Color.appPaper)
-                                .listRowSeparator(.hidden)
-                                .listRowInsets(EdgeInsets())
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack(spacing: 8) {
-                                    ForEach(wantToVisitCountries) { country in
-                                        NavigationLink {
-                                            CountryDetailScreen(country: country)
-                                        } label: {
-                                            VStack(spacing: 4) {
-                                                ZStack(alignment: .topTrailing) {
-                                                    Text(country.flagEmoji)
-                                                        .font(.system(size: 32))
-                                                    Image(systemName: "star.fill")
-                                                        .font(.caption2)
-                                                        .foregroundStyle(.orange)
-                                                        .offset(x: 4, y: -4)
-                                                }
-                                                Text(country.name)
-                                                    .font(.caption2)
-                                                    .lineLimit(1)
-                                                    .frame(width: 70)
-                                            }
-                                            .padding(8)
-                                            .background(.thinMaterial)
-                                            .clipShape(RoundedRectangle(cornerRadius: 12))
-                                        }
-                                        .buttonStyle(.plain)
-                                    }
-                                }
-                                .padding(.vertical, 4)
-                            }
-                            .listRowBackground(Color.appPaper)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 4, trailing: 0))
-                        }
+                        wishlistSection
+                            .padding(.top, 24)
                     }
 
-                    // MARK: - Visited by Continent
-                    Section {
-                        Text("Progress by Continent").eyebrowStyle()
-                            .padding(.horizontal, 16)
-                            .padding(.top, 8)
-                            .listRowBackground(Color.appPaper)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets())
-                        LazyVGrid(
-                            columns: [GridItem(.flexible(), spacing: 12),
-                                      GridItem(.flexible(), spacing: 12)],
-                            spacing: 12
-                        ) {
-                            ForEach(visitedByContinent, id: \.continent.id) { item in
-                                let accent = continentAccent(for: item.continent)
-                                VStack(alignment: .leading, spacing: 10) {
-                                    Text(item.continent.displayName)
-                                        .font(AppTypography.displaySmall)
-                                        .foregroundStyle(Color.appInk)
-                                    HStack(alignment: .firstTextBaseline, spacing: 4) {
-                                        Text("\(item.visited)")
-                                            .font(AppTypography.statLarge)
-                                            .foregroundStyle(Color.appInk)
-                                        Text("/ \(item.total)")
-                                            .font(AppTypography.bodySmall)
-                                            .foregroundStyle(Color.appInk3)
-                                    }
-                                    continentDots(visited: item.visited, total: item.total, accent: accent)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .topLeading)
-                                .padding(14)
-                                .background(accent.opacity(0.13))
-                                .clipShape(RoundedRectangle(cornerRadius: 16))
-                                .aspectRatio(1, contentMode: .fit)
-                            }
-                        }
-                        .listRowBackground(Color.appPaper)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
-                    }
-
-                    // MARK: - Visited Countries
                     if !visitedCountries.isEmpty {
-                        Section {
-                            Text("Visited Countries").eyebrowStyle()
-                                .padding(.horizontal, 16)
-                                .padding(.top, 8)
-                                .listRowBackground(Color.appPaper)
-                                .listRowSeparator(.hidden)
-                                .listRowInsets(EdgeInsets())
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack(spacing: 10) {
-                                    ForEach(Array(visitedCountries.enumerated()), id: \.element.id) { index, country in
-                                        let chipColors: [Color] = [.appRose, .appSky, .appLime, .appSunset, .appAqua, .appBlush]
-                                        let accent = chipColors[index % chipColors.count]
-                                        NavigationLink {
-                                            CountryDetailScreen(country: country)
-                                        } label: {
-                                            HStack(spacing: 7) {
-                                                Text(country.flagEmoji)
-                                                    .font(.system(size: 22))
-                                                Text(country.name)
-                                                    .font(AppTypography.bodySmall)
-                                                    .fontWeight(.medium)
-                                                    .foregroundStyle(Color.appInk)
-                                                    .lineLimit(1)
-                                            }
-                                            .padding(.vertical, 10)
-                                            .padding(.horizontal, 14)
-                                            .frame(maxWidth: 160)
-                                            .background(Color.appCard)
-                                            .clipShape(Capsule())
-                                            .overlay(Capsule().stroke(accent, lineWidth: 2))
-                                        }
-                                        .buttonStyle(.plain)
-                                    }
-                                }
-                                .padding(.vertical, 8)
-                                .padding(.horizontal, 14)
-                            }
-                            .listRowBackground(Color.appPaper)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 4, trailing: 0))
-                        }
+                        visitedCountriesSection
+                            .padding(.top, 24)
                     }
 
-                    // MARK: - Fresh Memories
+                    continentProgressSection
+                        .padding(.horizontal, 16)
+                        .padding(.top, 24)
+
+                    badgesSection
+                        .padding(.top, 24)
+
                     if !recentVisits.isEmpty {
-                        Section {
-                            Text("Fresh Memories").eyebrowStyle()
-                                .padding(.horizontal, 16)
-                                .padding(.top, 8)
-                                .listRowBackground(Color.appPaper)
-                                .listRowSeparator(.hidden)
-                                .listRowInsets(EdgeInsets())
-                            ForEach(
-                                Array(recentVisits.prefix(8).enumerated()),
-                                id: \.element.country.id
-                            ) { index, item in
-                                ZStack(alignment: .trailing) {
-                                    NavigationLink {
-                                        CountryDetailScreen(country: item.country)
-                                    } label: { EmptyView() }
-                                        .opacity(0)
-                                    HStack(spacing: 12) {
-                                        Text(item.country.flagEmoji)
-                                            .font(.system(size: 28))
-                                            .frame(width: 48, height: 48)
-                                            .background(Color.white)
-                                            .clipShape(RoundedRectangle(cornerRadius: 12))
-                                            .shadow(color: Color.appInk.opacity(0.07), radius: 4, x: 0, y: 2)
-                                        VStack(alignment: .leading, spacing: 3) {
-                                            Text(item.country.name)
-                                                .font(AppTypography.displaySmall)
-                                                .foregroundStyle(Color.appInk)
-                                            HStack(spacing: 4) {
-                                                Text(formattedDate(item.date))
-                                                    .foregroundStyle(memoryCardAccent(at: index))
-                                                let photos = photoCount(for: item.country.id)
-                                                if photos > 0 {
-                                                    Text("·")
-                                                        .foregroundStyle(Color.appInk3)
-                                                    Text("\(photos) photos")
-                                                        .foregroundStyle(Color.appInk3)
-                                                }
-                                            }
-                                            .font(AppTypography.bodySmall)
-                                            .fontWeight(.medium)
-                                        }
-                                        Spacer()
-                                        Image(systemName: "chevron.right")
-                                            .font(.caption2)
-                                            .fontWeight(.semibold)
-                                            .foregroundStyle(Color.appInk3)
-                                    }
+                        recentMemoriesSection
+                            .padding(.horizontal, 16)
+                            .padding(.top, 24)
+                    }
+
+                    Spacer().frame(height: 32)
+                }
+            }
+            .background(Color(hex: "#F7F7F7"))
+            .navigationTitle("Stats")
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(item: $selectedAchievement) { achievement in
+                BadgeDetailSheet(achievement: achievement)
+                    .presentationDetents([.medium])
+                    .presentationDragIndicator(.visible)
+                    .presentationCornerRadius(24)
+            }
+        }
+    }
+
+    // MARK: - Overview
+
+    private var overviewSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionLabel("Overview")
+            VStack(alignment: .leading, spacing: 10) {
+                Text("\(visitedCountriesCount) / \(totalCountriesCount) Countries")
+                    .font(.system(size: 34, weight: .bold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .tracking(-0.5)
+
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(Color(hex: "#EEEEEE"))
+                            .frame(height: 4)
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(Color(hex: "#1b1b1b"))
+                            .frame(
+                                width: max(geo.size.width * (visitedPercentage / 100), visitedCountriesCount > 0 ? 6 : 0),
+                                height: 4
+                            )
+                    }
+                }
+                .frame(height: 4)
+
+                Text(String(format: "%.1f%% of the world", visitedPercentage))
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+            }
+            .padding(16)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+        }
+    }
+
+    // MARK: - Summary
+
+    private var summarySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionLabel("Summary")
+            HStack(spacing: 12) {
+                summaryCard(
+                    value: "\(visitedThisYear.count)",
+                    label: "Visited this year",
+                    sublabel: "Countries"
+                )
+                summaryCard(
+                    value: "\(wantToVisitCount)",
+                    label: "On Wishlist",
+                    sublabel: "Planning"
+                )
+            }
+        }
+    }
+
+    private func summaryCard(value: String, label: String, sublabel: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(value)
+                .font(.system(size: 40, weight: .bold))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .tracking(-0.5)
+            Text(label)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .padding(.top, 2)
+            Text(sublabel)
+                .font(.system(size: 12))
+                .foregroundStyle(Color(hex: "#9E9E9E"))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+    }
+
+    // MARK: - Wishlist
+
+    private var wishlistSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionLabel("Wishlist")
+                .padding(.horizontal, 16)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(wantToVisitCountries) { country in
+                        NavigationLink {
+                            CountryDetailScreen(country: country)
+                        } label: {
+                            VStack(spacing: 6) {
+                                ZStack(alignment: .topTrailing) {
+                                    Text(country.flagEmoji)
+                                        .font(.system(size: 34))
+                                        .frame(width: 50, height: 50)
+                                    Image(systemName: "star.fill")
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(Color(hex: "#4A90D9"))
+                                        .offset(x: 2, y: -2)
                                 }
-                                .contentShape(Rectangle())
-                                .padding(14)
-                                .background(memoryCardBG(at: index))
-                                .clipShape(RoundedRectangle(cornerRadius: 18))
-                                .listRowBackground(Color.appPaper)
-                                .listRowSeparator(.hidden)
-                                .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                                .padding(10)
+                                .background(Color.white)
+                                .clipShape(RoundedRectangle(cornerRadius: 14))
+                                .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+
+                                Text(country.name)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                                    .lineLimit(1)
+                            }
+                            .frame(width: 70)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+
+    // MARK: - Visited Countries
+
+    private var visitedCountriesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionLabel("All visited countries")
+                .padding(.horizontal, 16)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(visitedCountries) { country in
+                        NavigationLink {
+                            CountryDetailScreen(country: country)
+                        } label: {
+                            VStack(spacing: 6) {
+                                Text(country.flagEmoji)
+                                    .font(.system(size: 34))
+                                    .frame(width: 50, height: 50)
+                                    .padding(10)
+                                    .background(Color.white)
+                                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                                    .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+
+                                Text(country.name)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                                    .lineLimit(1)
+                            }
+                            .frame(width: 70)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+
+    // MARK: - Continent Progress
+
+    private var continentProgressSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionLabel("Continent progress")
+            VStack(spacing: 0) {
+                ForEach(Array(visitedByContinent.enumerated()), id: \.element.continent.id) { index, item in
+                    if index > 0 {
+                        Divider()
+                            .padding(.horizontal, 16)
+                    }
+                    HStack(spacing: 12) {
+                        Text(continentShortName(item.continent))
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .frame(width: 84, alignment: .leading)
+
+                        GeometryReader { geo in
+                            ZStack(alignment: .leading) {
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(Color(hex: "#EEEEEE"))
+                                    .frame(height: 6)
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(Color(hex: "#1b1b1b"))
+                                    .frame(
+                                        width: max(geo.size.width * (item.percentage / 100), item.visited > 0 ? 6 : 0),
+                                        height: 6
+                                    )
                             }
                         }
-                    }
+                        .frame(height: 6)
 
-                }
-                .scrollContentBackground(.hidden)
-
-                // Loading overlay (unchanged)
-                if vm.isLoading {
-                    VStack(spacing: 16) {
-                        ProgressView()
-                            .scaleEffect(1.5)
-                        Text("Loading statistics...")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
+                        Text("\(item.visited)/\(item.total)")
+                            .font(.system(size: 12))
+                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .frame(width: 38, alignment: .trailing)
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color(.systemBackground).opacity(0.9))
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
                 }
             }
-            .background(Color.appPaper)
-            .toolbar(.hidden, for: .navigationBar)
-            .listStyle(.plain)
-        }
-    }
-    
-    // MARK: - Helper Methods
-    
-    private func continentColor(for percentage: Double) -> Color {
-        switch percentage {
-        case 75...:
-            return .green
-        case 50..<75:
-            return .blue
-        case 25..<50:
-            return .orange
-        default:
-            return .red
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         }
     }
 
-    private func continentAccent(for continent: Continent) -> Color {
+    // MARK: - Badges
+
+    private var badgesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionLabel("Badges")
+                .padding(.horizontal, 16)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(achievements) { achievement in
+                        AchievementCard(achievement: achievement) {
+                            selectedAchievement = achievement
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    // MARK: - Recent Memories
+
+    private var recentMemoriesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionLabel("Recent memories")
+            ForEach(Array(recentVisits.prefix(5)), id: \.country.id) { item in
+                NavigationLink {
+                    CountryDetailScreen(country: item.country)
+                } label: {
+                    memoryCard(country: item.country, date: item.date)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func memoryCard(country: Country, date: Date?) -> some View {
+        let visit = visitedVisits.first { $0.countryId == country.id }
+        let firstPhoto = visit?.photos.first
+        let notes = visit?.notes ?? ""
+
+        return VStack(alignment: .leading, spacing: 0) {
+            if let photo = firstPhoto, let uiImage = UIImage(data: photo.imageData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 200)
+                    .clipped()
+            } else {
+                Text(country.flagEmoji)
+                    .font(.system(size: 64))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 120)
+                    .background(Color(hex: "#F3F3F3"))
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(country.name)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                if !notes.isEmpty {
+                    Text("\"\(notes)\"")
+                        .font(.system(size: 13))
+                        .italic()
+                        .foregroundStyle(Color(hex: "#6B6B6B"))
+                        .lineLimit(2)
+                }
+                if let date {
+                    Text(date.formatted(date: .abbreviated, time: .omitted).uppercased())
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .tracking(0.5)
+                        .padding(.top, 2)
+                }
+            }
+            .padding(16)
+        }
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Helpers
+
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 17, weight: .bold))
+            .foregroundStyle(Color(hex: "#1b1b1b"))
+    }
+
+    private func continentShortName(_ continent: Continent) -> String {
         switch continent {
-        case .africa:       return .appSunset
-        case .antarctica:   return .appSky
-        case .asia:         return .appRose
-        case .europe:       return .appSky
-        case .northAmerica: return .appLime
-        case .oceania:      return .appSunset
-        case .southAmerica: return .appRose
-        }
-    }
-    
-    private func photoCount(for countryId: String) -> Int {
-        visitedVisits.first { $0.countryId == countryId }?.photos.count ?? 0
-    }
-
-    private func continentDots(visited: Int, total: Int, accent: Color) -> some View {
-        let cols = Array(repeating: GridItem(.fixed(5), spacing: 3), count: 16)
-        return LazyVGrid(columns: cols, alignment: .leading, spacing: 3) {
-            ForEach(0..<min(total, 48), id: \.self) { i in
-                Circle()
-                    .fill(i < visited ? accent : accent.opacity(0.22))
-                    .frame(width: 5, height: 5)
-            }
+        case .northAmerica: return "N. America"
+        case .southAmerica: return "S. America"
+        default: return continent.displayName
         }
     }
 
-    private func memoryCardBG(at index: Int) -> Color {
-        switch index % 4 {
-        case 0:  return .appAqua
-        case 1:  return .appBlush
-        case 2:  return .appLime.opacity(0.30)
-        default: return .appSunset.opacity(0.22)
-        }
-    }
+    // MARK: - ViewModel
 
-    private func memoryCardAccent(at index: Int) -> Color {
-        switch index % 4 {
-        case 0:  return .appSky
-        case 1:  return .appRose
-        case 2:  return .appLime
-        default: return .appSunset
-        }
-    }
-
-    private func formattedDate(_ date: Date?) -> String {
-        guard let date else { return "—" }
-        return date.formatted(date: .abbreviated, time: .omitted)
-    }
-    
-    // MARK: - Stats ViewModel
-    
     @MainActor
     final class StatsViewModel: ObservableObject {
         @Published private(set) var countries: [Country] = []
         @Published private(set) var isLoading = false
-        
+
         private let service = CountryDataService.shared
-        
-        init() {
-            #if DEBUG
-            print("📊 StatsViewModel initialized")
-            #endif
-            load()
-        }
-        
+
+        init() { load() }
+
         func load() {
-            #if DEBUG
-            print("📊 StatsViewModel.load() called")
-            #endif
             isLoading = true
-            
-            // Load countries
             Task(priority: .userInitiated) {
-                #if DEBUG
-                print("📊 About to call CountryDataService.loadCountries()")
-                #endif
-                let loadedCountries = service.loadCountries()
-                #if DEBUG
-                print("📊 Received \(loadedCountries.count) countries from service")
-                #endif
-                
-                self.countries = loadedCountries
+                let loaded = service.loadCountries()
+                self.countries = loaded
                 self.isLoading = false
-                #if DEBUG
-                print("📊 Updated StatsViewModel with \(loadedCountries.count) countries")
-                #endif
             }
         }
-        
-        // MARK: - Achievements
-        
-        /// Calculate achievements based on current visit data
-        /// - Parameter visits: Dictionary of all visits from AppState
-        /// - Returns: Array of achievements with unlock status
+
         func achievements(from visits: [String: Visit]) -> [Achievement] {
-            return AchievementEngine.calculateAchievements(
-                visits: visits,
-                countries: countries
-            )
-        }
-    }
-    
-    // MARK: - Supporting Views
-
-    private struct ConfettiWave: Shape {
-        func path(in rect: CGRect) -> Path {
-            var p = Path()
-            p.move(to: CGPoint(x: 0, y: rect.midY))
-            p.addCurve(
-                to: CGPoint(x: rect.width / 2, y: rect.midY),
-                control1: CGPoint(x: rect.width * 0.15, y: 0),
-                control2: CGPoint(x: rect.width * 0.35, y: rect.height)
-            )
-            p.addCurve(
-                to: CGPoint(x: rect.width, y: rect.midY),
-                control1: CGPoint(x: rect.width * 0.65, y: 0),
-                control2: CGPoint(x: rect.width * 0.85, y: rect.height)
-            )
-            return p
+            AchievementEngine.calculateAchievements(visits: visits, countries: countries)
         }
     }
 
-    private struct MiniStatCard: View {
-        let value: String
-        let label: String
-        let background: Color
-        let foreground: Color
+    // MARK: - Achievement Card
 
-        var body: some View {
-            VStack(alignment: .leading, spacing: 0) {
-                Text(value)
-                    .font(AppTypography.statLarge)
-                    .foregroundStyle(foreground)
-                Spacer()
-                Text(label)
-                    .font(AppTypography.caption)
-                    .foregroundStyle(foreground.opacity(0.75))
-            }
-            .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
-            .padding(16)
-            .background(background)
-            .clipShape(RoundedRectangle(cornerRadius: 18))
-            .shadow(color: Color.appInk.opacity(0.06), radius: 8, x: 0, y: 3)
-        }
-    }
-    
     private struct AchievementCard: View {
         let achievement: Achievement
+        let onTap: () -> Void
 
-        private var palette: (bg: Color, fg: Color) {
-            guard achievement.isUnlocked else {
-                return (bg: .appCard, fg: .appInk)
-            }
-            switch achievement.type {
-            case .firstCountry:         return (bg: .appRose,   fg: .white)
-            case .firstNote:            return (bg: .appBlush,  fg: .appInk)
-            case .firstPhoto:           return (bg: .appAqua,   fg: .appInk)
-            case .countries(let n):     return n <= 5
-                                            ? (bg: .appLime,    fg: .appInk)
-                                            : (bg: .appSunset,  fg: .white)
-            case .continents:           return (bg: .appBlush,  fg: .appInk)
-            case .allContinents:        return (bg: .appAqua,   fg: .appInk)
-            }
-        }
-
-        private var shortLabel: String {
-            switch achievement.type {
-            case .firstCountry:         return "First Country"
-            case .firstNote:            return "First Note"
-            case .firstPhoto:           return "First Photo"
-            case .countries(let n):     return "\(n) Countries"
-            case .continents(let n):    return "\(n) Continents"
-            case .allContinents:        return "All Continents"
-            }
-        }
+        private var label: String { achievement.badgeLabel }
 
         var body: some View {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(achievement.isUnlocked ? "🏆" : "🔒")
-                    .font(.system(size: 28))
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(shortLabel)
-                        .font(AppTypography.displaySmall)
-                        .foregroundStyle(palette.fg)
+            Button(action: onTap) {
+                VStack(spacing: 8) {
+                    Text(achievement.isUnlocked ? "🏆" : "🔒")
+                        .font(.system(size: 30))
+                    Text(label)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
                         .lineLimit(2)
-                        .minimumScaleFactor(0.8)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(width: 90, height: 90)
+                .background(achievement.isUnlocked ? Color(hex: "#FFF9E6") : Color(hex: "#F3F3F3"))
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
+                .opacity(achievement.isUnlocked ? 1.0 : 0.6)
+            }
+            .buttonStyle(.plain)
+        }
+    }
 
-                    Text(achievement.isUnlocked ? "Unlocked" : "Locked")
-                        .font(AppTypography.eyebrow)
-                        .fontWeight(.bold)
-                        .tracking(1.2)
-                        .textCase(.uppercase)
-                        .foregroundStyle(palette.fg.opacity(achievement.isUnlocked ? 0.82 : 0.45))
+    private struct BadgeDetailSheet: View {
+        let achievement: Achievement
+        @Environment(\.dismiss) private var dismiss
+
+        var body: some View {
+            VStack(spacing: 0) {
+                // Header
+                VStack(spacing: 12) {
+                    Text(achievement.isUnlocked ? "🏆" : "🔒")
+                        .font(.system(size: 56))
+                        .padding(.top, 32)
+
+                    Text(achievement.badgeLabel)
+                        .font(.system(size: 22, weight: .bold))
+                        .foregroundStyle(Color(hex: "#1b1b1b"))
+
+                    Text(achievement.isUnlocked ? "UNLOCKED" : "LOCKED")
+                        .font(.system(size: 11, weight: .bold))
+                        .tracking(1.5)
+                        .foregroundStyle(achievement.isUnlocked ? Color(hex: "#1E7F4E") : Color(hex: "#9E9E9E"))
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 5)
+                        .background(achievement.isUnlocked ? Color(hex: "#1E7F4E").opacity(0.1) : Color(hex: "#F3F3F3"))
+                        .clipShape(Capsule())
                 }
-            }
-            .frame(width: 110, height: 110, alignment: .leading)
-            .padding(13)
-            .background(palette.bg)
-            .overlay {
-                if !achievement.isUnlocked {
-                    RoundedRectangle(cornerRadius: 22)
-                        .stroke(Color.appLine, lineWidth: 1)
+
+                // Info card
+                VStack(alignment: .leading, spacing: 16) {
+                    infoRow(title: "ABOUT", body: achievement.badgeDescription)
+                    if !achievement.isUnlocked {
+                        Divider()
+                        infoRow(title: "HOW TO UNLOCK", body: achievement.unlockRequirement)
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+                .background(Color(hex: "#F7F7F7"))
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .padding(.horizontal, 24)
+                .padding(.top, 24)
+
+                Spacer()
             }
-            .clipShape(RoundedRectangle(cornerRadius: 22))
-            .shadow(
-                color: Color.appInk.opacity(achievement.isUnlocked ? 0.09 : 0.04),
-                radius: achievement.isUnlocked ? 12 : 5,
-                x: 0,
-                y: achievement.isUnlocked ? 6 : 2
-            )
-            .opacity(achievement.isUnlocked ? 1.0 : 0.88)
+            .frame(maxWidth: .infinity)
+            .background(Color.white)
+        }
+
+        private func infoRow(title: String, body: String) -> some View {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .tracking(0.8)
+                Text(body)
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 }
+
+// MARK: - Achievement display helpers
+
+private extension Achievement {
+    var badgeLabel: String {
+        switch type {
+        case .firstCountry:     return "Nomad"
+        case .firstNote:        return "Journalist"
+        case .firstPhoto:       return "Photographer"
+        case .countries(let n): return "\(n) Countries"
+        case .continents(let n):return "\(n) Continents"
+        case .allContinents:    return "Jetsetter"
+        }
+    }
+
+    var badgeDescription: String {
+        switch type {
+        case .firstCountry:
+            return "Awarded to explorers who have visited their first country. Every great journey starts with a single step."
+        case .firstNote:
+            return "Awarded to travellers who have written their first memory. Words keep the spirit of a journey alive."
+        case .firstPhoto:
+            return "Awarded to those who captured their first travel photo. A picture is worth a thousand memories."
+        case .countries(let n):
+            return "Awarded for visiting \(n) countries. The world is vast, and you are making your mark on it."
+        case .continents(let n):
+            return "Awarded for setting foot on \(n) different continents. You are a true multi-continental explorer."
+        case .allContinents:
+            return "Awarded to the rare few who have visited all 7 continents. The world is your home."
+        }
+    }
+
+    var unlockRequirement: String {
+        switch type {
+        case .firstCountry:
+            return "Mark any country as visited."
+        case .firstNote:
+            return "Add a note to any visited country."
+        case .firstPhoto:
+            return "Add a photo to any visited country."
+        case .countries(let n):
+            return "Visit \(n) countries in total."
+        case .continents(let n):
+            return "Visit at least one country on \(n) different continents."
+        case .allContinents:
+            return "Visit at least one country on every continent."
+        }
+    }
+}
+
 // MARK: - Visited This Year List View
 
 struct VisitedThisYearListView: View {
     let visits: [(country: Country, date: Date)]
-    
+
     var body: some View {
         List {
             ForEach(visits, id: \.country.id) { item in
@@ -750,7 +631,6 @@ struct VisitedThisYearListView: View {
                     HStack(spacing: 12) {
                         Text(item.country.flagEmoji)
                             .font(.title2)
-                        
                         VStack(alignment: .leading, spacing: 2) {
                             Text(item.country.name)
                                 .font(.body)
@@ -758,10 +638,8 @@ struct VisitedThisYearListView: View {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
-                        
                         Spacer()
-                        
-                        Text(formattedDate(item.date))
+                        Text(item.date.formatted(date: .abbreviated, time: .omitted))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -772,9 +650,4 @@ struct VisitedThisYearListView: View {
         .navigationTitle("Visited This Year")
         .navigationBarTitleDisplayMode(.inline)
     }
-    
-    private func formattedDate(_ date: Date) -> String {
-        date.formatted(date: .abbreviated, time: .omitted)
-    }
 }
-


### PR DESCRIPTION
Closes #147 

 ## Summary                                                
                                                                                                    
  - **Design system**: Replaced the old colorful palette with a clean system                        
    derived from the map's own accent colors — red (#F9234D) for visited,                           
    sky blue (#4A90D9) for wishlist, gold for achievements, green for                               
    confirmed states. Neutral chrome throughout.                                                    
  - **Compare screen**: Built from scratch — friend email search, dark hero                         
    results card with shared/only-you/only-them country sections and badges,                        
    plan-a-trip shortcut for wishlist matches.                                                      
  - **Map screen**: Collapsible "Where have you been?" bottom popup with recent                     
    visits, memories photo grid sheet, filter chips (All / Visited / Wishlist),                     
    redesigned quick action sheet, legend card, zoom controls.                                      
  - **Stats screen**: Overhauled layout — overview progress bar, summary cards,
    horizontal country scrollers, continent progress, badge cards with detail                       
    sheet, recent memories cards with photo support.        
  - **Countries screen**: Continent grid with per-continent accent colors,                          
    alphabetical country list with search and filter chips. 
  - **Country detail screen**: Dark hero card (matching compare style), status                      
    card with icon circles, notes editor, 2×2 photo grid, full-screen viewer.                       
  - **Account screen**: Custom scroll layout replacing system list — profile                        
    section, visited progress (red bar), highlights card, privacy toggle.                           
  - **Auth screen**: Minimal Uber-style layout with Inter font, flat inputs,                        
    single black CTA.                                       
  - **App launch**: Custom stroke spinner, lettertracked wordmark, tagline.                         
  - **Service layer**: `setVisit()` for atomic Firestore writes, `displayName`                      
    on AuthService, first/last name support, profile and sync improvements.                         
                                                                                                    
  ## Test plan                                              
                                                                                                    
  - [ ] Sign up with first + last name, verify display name appears in Account                      
  - [ ] Mark countries visited/wishlist, verify map colors match legend dots
  - [ ] Compare with a user who has enabled comparison; verify badge sections                       
  - [ ] Compare with a user who has disabled comparison; verify error state                         
  - [ ] Add photos to a visited country; verify they appear in Map Memories sheet                   
  - [ ] Tap all continent cards, verify colors and counts are correct                               
  - [ ] Open Badge detail sheet for locked and unlocked achievements                                
  - [ ] Change password flow end-to-end                                                             
  - [ ] Delete account warning icons and confirmation flow