### PR TITLE
fix: photos not visible on second device after sign-in

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
@@ -80,9 +80,7 @@ final class FirestoreVisitRepository {
         )
     }
 
-    /// Writes visit metadata atomically in a single Firestore write.
-    /// Photos are intentionally excluded — Firestore has a 1 MB document limit and
-    /// Base64-encoded images blow past it quickly. Photos live in local storage only.
+    /// Writes a full visit snapshot to Firestore, including photos.
     func setVisit(_ visit: Visit) async throws {
         let userID = try requireUserID()
         let ref = db.collection("users")
@@ -90,13 +88,17 @@ final class FirestoreVisitRepository {
             .collection("visits")
             .document(visit.countryId)
 
-        let data: [String: Any] = [
+        var data: [String: Any] = [
             "isVisited": visit.isVisited,
             "wantToVisit": visit.wantToVisit,
             "visitedDate": visit.visitedDate as Any,
             "notes": visit.notes,
             "updatedAt": Timestamp(date: visit.updatedAt)
         ]
+
+        if !visit.photos.isEmpty {
+            data["photos"] = try encodePhotosToBase64(visit.photos)
+        }
 
         try await setData(data, for: ref)
     }

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
@@ -218,12 +218,15 @@ final class SyncService {
     }
 
     private func saveToLocal(_ visit: Visit) throws {
-        // Photos are local-only (not synced to Firestore), so always preserve whatever
-        // photos are already stored on this device.
-        var mergedVisit = visit
-        let existingVisit = try? localRepository.visit(for: visit.countryId)
-        mergedVisit.photos = existingVisit?.photos ?? []
-        try localRepository.upsert(mergedVisit)
+        var merged = visit
+        // If the cloud document has no photos (e.g. written by an older app version before
+        // photo sync was added), fall back to whatever is already on this device so we don't
+        // silently wipe locally-stored photos.
+        if merged.photos.isEmpty {
+            let existing = try? localRepository.visit(for: visit.countryId)
+            merged.photos = existing?.photos ?? []
+        }
+        try localRepository.upsert(merged)
     }
 }
 


### PR DESCRIPTION
Two bugs combined to make photos invisible on any device other than the one they were added on:

1. FirestoreVisitRepository.setVisit() used setData() (full document overwrite) without a photos field, so any sync push triggered by a notes or visited-date change silently deleted the photos field from Firestore.

2. SyncService.saveToLocal() always replaced incoming cloud photos with whatever was on the local device (photos = existingVisit?.photos ?? []), so on a fresh device every cloud photo was discarded before being written to SwiftData.

Fix: include photos in setVisit() writes; use cloud photos in saveToLocal(), falling back to local only when the cloud document has none (backwards compat with pre-photo-sync documents).