### PR TITLE
fix: migrate photo sync to Firestore subcollection

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Persistence/FirestoreVisitRepository.swift
@@ -80,7 +80,7 @@ final class FirestoreVisitRepository {
         )
     }
 
-    /// Writes a full visit snapshot to Firestore, including photos.
+    /// Writes visit metadata to Firestore. Photos are stored separately in the photos subcollection.
     func setVisit(_ visit: Visit) async throws {
         let userID = try requireUserID()
         let ref = db.collection("users")
@@ -88,17 +88,13 @@ final class FirestoreVisitRepository {
             .collection("visits")
             .document(visit.countryId)
 
-        var data: [String: Any] = [
+        let data: [String: Any] = [
             "isVisited": visit.isVisited,
             "wantToVisit": visit.wantToVisit,
             "visitedDate": visit.visitedDate as Any,
             "notes": visit.notes,
             "updatedAt": Timestamp(date: visit.updatedAt)
         ]
-
-        if !visit.photos.isEmpty {
-            data["photos"] = try encodePhotosToBase64(visit.photos)
-        }
 
         try await setData(data, for: ref)
     }
@@ -427,8 +423,63 @@ final class FirestoreVisitRepository {
         return .unknown(error)
     }
     
-    // MARK: - Photo encoding
-    
+    // MARK: - Photo Subcollection
+
+    /// Syncs photos for a country using the photos subcollection.
+    /// Uploads local-only photos to cloud and returns the union of local + cloud-only photos.
+    func syncPhotos(countryId: String, localPhotos: [VisitPhoto]) async throws -> [VisitPhoto] {
+        let userID = try requireUserID()
+        let ref = photosCollection(userID: userID, countryId: countryId)
+        let snapshot = try await getDocuments(from: ref)
+        let cloudPhotos = snapshot.documents.compactMap { photoFromDocument($0) }
+
+        let cloudIds = Set(cloudPhotos.map { $0.id })
+        let localIds  = Set(localPhotos.map { $0.id })
+
+        for photo in localPhotos where !cloudIds.contains(photo.id) {
+            try await setData(photoDocument(photo), for: ref.document(photo.id.uuidString))
+        }
+
+        return localPhotos + cloudPhotos.filter { !localIds.contains($0.id) }
+    }
+
+    func deletePhoto(countryId: String, photoId: UUID) async throws {
+        let userID = try requireUserID()
+        try await deleteDocument(
+            photosCollection(userID: userID, countryId: countryId).document(photoId.uuidString)
+        )
+    }
+
+    private func photosCollection(userID: String, countryId: String) -> CollectionReference {
+        db.collection("users")
+            .document(userID)
+            .collection("visits")
+            .document(countryId)
+            .collection("photos")
+    }
+
+    private func photoDocument(_ photo: VisitPhoto) -> [String: Any] {
+        [
+            "imageData": photo.imageData.base64EncodedString(),
+            "caption": photo.caption,
+            "createdAt": Timestamp(date: photo.createdAt)
+        ]
+    }
+
+    private func photoFromDocument(_ doc: QueryDocumentSnapshot) -> VisitPhoto? {
+        let data = doc.data()
+        guard let s = data["imageData"] as? String,
+              let imageData = Data(base64Encoded: s) else { return nil }
+        return VisitPhoto(
+            id: UUID(uuidString: doc.documentID) ?? UUID(),
+            imageData: imageData,
+            caption: data["caption"] as? String ?? "",
+            createdAt: (data["createdAt"] as? Timestamp)?.dateValue() ?? Date()
+        )
+    }
+
+    // MARK: - Photo encoding (legacy: used by addPhoto/removePhoto/updatePhotoCaption)
+
     private func encodePhotosToBase64(_ photos: [VisitPhoto]) throws -> String {
         let jsonData = try JSONEncoder().encode(photos)
         return jsonData.base64EncodedString()

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/SyncService.swift
@@ -154,13 +154,43 @@ final class SyncService {
         }
             
             #if DEBUG
-            print("✅ Sync complete: \(syncedCount) synced, \(errorCount) errors")
+            print("✅ Metadata sync complete: \(syncedCount) synced, \(errorCount) errors")
             #endif
-            
-            // If there were any errors, throw an aggregate error
+
             if errorCount > 0 {
                 throw SyncError.partialFailure(syncedCount: syncedCount, failedCount: errorCount)
             }
+
+            // Phase 2: Photo sync via subcollection (no 1 MB document size limit).
+            // Errors here are non-fatal — metadata sync already succeeded.
+            // Re-read local state — some visits may have been added by saveToLocal above.
+            let currentLocalVisits = try localRepository.allVisits()
+            let currentLocalById = Dictionary(uniqueKeysWithValues: currentLocalVisits.map { ($0.countryId, $0) })
+
+            for countryId in allCountryIDs {
+                let localPhotos = currentLocalById[countryId]?.photos ?? []
+                do {
+                    let mergedPhotos = try await cloudRepository.syncPhotos(
+                        countryId: countryId, localPhotos: localPhotos
+                    )
+                    if mergedPhotos.count != localPhotos.count,
+                       var localVisit = currentLocalById[countryId] {
+                        localVisit.photos = mergedPhotos
+                        try localRepository.upsert(localVisit)
+                    }
+                } catch let error as FirestoreVisitRepositoryError where error == .offline {
+                    throw error  // propagates to outer catch → .noConnection
+                } catch {
+                    #if DEBUG
+                    print("⚠️ Photo sync failed for \(countryId): \(error)")
+                    #endif
+                    // Non-fatal: metadata sync succeeded; photos will retry on next sync
+                }
+            }
+
+            #if DEBUG
+            print("✅ Photo sync complete")
+            #endif
         } catch {
             // Check if it's a network error
             let nsError = error as NSError
@@ -211,22 +241,31 @@ final class SyncService {
     }
 
     private func pushToCloud(_ visit: Visit) async throws {
-        // Write all visit fields including photos in a single atomic Firestore write.
-        // The old approach called setVisited (which wiped the photos field) then added
-        // photos one-by-one with try?, causing photo loss on any network hiccup.
         try await cloudRepository.setVisit(visit)
     }
 
     private func saveToLocal(_ visit: Visit) throws {
         var merged = visit
-        // If the cloud document has no photos (e.g. written by an older app version before
-        // photo sync was added), fall back to whatever is already on this device so we don't
-        // silently wipe locally-stored photos.
-        if merged.photos.isEmpty {
-            let existing = try? localRepository.visit(for: visit.countryId)
-            merged.photos = existing?.photos ?? []
+        let existing = try? localRepository.visit(for: visit.countryId)
+        if let existing, !existing.photos.isEmpty {
+            // Prefer local photos; photo subcollection sync handles cross-device transfer
+            merged.photos = existing.photos
         }
+        // If no existing local photos, preserve any photos decoded from the legacy "photos"
+        // field (old Firestore format) so the first sync on a new device migrates them.
         try localRepository.upsert(merged)
+    }
+
+    /// Deletes a single photo from the Firestore photos subcollection. Best-effort — errors are logged but not thrown.
+    func deleteCloudPhoto(countryId: String, photoId: UUID) async {
+        guard Auth.auth().currentUser != nil else { return }
+        do {
+            try await cloudRepository.deletePhoto(countryId: countryId, photoId: photoId)
+        } catch {
+            #if DEBUG
+            print("⚠️ Failed to delete cloud photo \(photoId) for \(countryId): \(error)")
+            #endif
+        }
     }
 }
 

--- a/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AppState.swift
@@ -371,14 +371,17 @@ final class AppState: ObservableObject {
         var v = visit(for: countryId)
         v.photos.removeAll { $0.id == photoId }
         v.updatedAt = Date()
-        
+
         // OPTIMIZATION: Manual notification to avoid triggering @Published twice
         objectWillChange.send()
         visits[countryId] = v
-        
+
         do {
             try repository.removePhoto(countryId, photoId: photoId)
             Task {
+                // Delete from cloud subcollection first so the subsequent full sync
+                // doesn't re-download the just-deleted photo.
+                await syncService?.deleteCloudPhoto(countryId: countryId, photoId: photoId)
                 await syncWithCloud(showStatus: false)
             }
         } catch {


### PR DESCRIPTION
Summary                                                                                           
                                                                                                    
  - Photos stored as a Base64 blob in the visit document hit Firestore's 1 MB limit at 3+ photos and
   silently failed to sync                                                                          
  - Migrated to a photos subcollection (users/{uid}/visits/{countryId}/photos/{photoId}) — each     
  photo is its own document with no size ceiling                                                    
  - Sync runs in two phases: visit metadata first, then per-country photo sync — photo errors are 
  non-fatal so a single country's failure doesn't break the whole sync                              
  - removePhoto now explicitly deletes from the cloud subcollection before triggering a full sync,
  preventing deleted photos from being re-downloaded                                                
                                                            
Firestore rules

  The photos subcollection rule (nested inside the visits block) is required and has been deployed:
  match /photos/{photoId} {                                                                         
    allow read, write: if request.auth.uid == userId;
  }                                                                                                 