### PR TITLE
Feat/google sign in

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/project.pbxproj
+++ b/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/project.pbxproj
@@ -10,15 +10,30 @@
 		0424509F2F5EA5D200ECE1D6 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 0424509E2F5EA5D200ECE1D6 /* FirebaseAuth */; };
 		042450A12F5EA5D200ECE1D6 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 042450A02F5EA5D200ECE1D6 /* FirebaseCore */; };
 		042450A32F5EA5D200ECE1D6 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 042450A22F5EA5D200ECE1D6 /* FirebaseFirestore */; };
+		04CB46122FAD28CA00883B87 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 04CB46112FAD28CA00883B87 /* GoogleSignIn */; };
+		04CB46142FAD28CA00883B87 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 04CB46132FAD28CA00883B87 /* GoogleSignInSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		04ACF9D52F4E45E0004448FC /* WorldTrackerIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WorldTrackerIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		04CB460F2FAD286100883B87 /* Exceptions for "WorldTrackerIOS" folder in "WorldTrackerIOS" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 04ACF9D42F4E45E0004448FC /* WorldTrackerIOS */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		04ACF9D72F4E45E0004448FC /* WorldTrackerIOS */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				04CB460F2FAD286100883B87 /* Exceptions for "WorldTrackerIOS" folder in "WorldTrackerIOS" target */,
+			);
 			path = WorldTrackerIOS;
 			sourceTree = "<group>";
 		};
@@ -29,7 +44,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				04CB46142FAD28CA00883B87 /* GoogleSignInSwift in Frameworks */,
 				042450A12F5EA5D200ECE1D6 /* FirebaseCore in Frameworks */,
+				04CB46122FAD28CA00883B87 /* GoogleSignIn in Frameworks */,
 				0424509F2F5EA5D200ECE1D6 /* FirebaseAuth in Frameworks */,
 				042450A32F5EA5D200ECE1D6 /* FirebaseFirestore in Frameworks */,
 			);
@@ -77,6 +94,8 @@
 				0424509E2F5EA5D200ECE1D6 /* FirebaseAuth */,
 				042450A02F5EA5D200ECE1D6 /* FirebaseCore */,
 				042450A22F5EA5D200ECE1D6 /* FirebaseFirestore */,
+				04CB46112FAD28CA00883B87 /* GoogleSignIn */,
+				04CB46132FAD28CA00883B87 /* GoogleSignInSwift */,
 			);
 			productName = WorldTrackerIOS;
 			productReference = 04ACF9D52F4E45E0004448FC /* WorldTrackerIOS.app */;
@@ -108,6 +127,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				0424509D2F5EA5D200ECE1D6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				04CB46102FAD28CA00883B87 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 04ACF9D62F4E45E0004448FC /* Products */;
@@ -269,6 +289,7 @@
 				DEVELOPMENT_TEAM = LT76D3X9J2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = WorldTrackerIOS/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "World Tracker";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -303,6 +324,7 @@
 				DEVELOPMENT_TEAM = LT76D3X9J2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = WorldTrackerIOS/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "World Tracker";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -359,6 +381,14 @@
 				minimumVersion = 12.10.0;
 			};
 		};
+		04CB46102FAD28CA00883B87 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.1.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -376,6 +406,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0424509D2F5EA5D200ECE1D6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseFirestore;
+		};
+		04CB46112FAD28CA00883B87 /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 04CB46102FAD28CA00883B87 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
+		};
+		04CB46132FAD28CA00883B87 /* GoogleSignInSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 04CB46102FAD28CA00883B87 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignInSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/project.pbxproj
+++ b/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/project.pbxproj
@@ -302,8 +302,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				EXECUTABLE_NAME = WorldTrackerIOS;
 				PRODUCT_BUNDLE_IDENTIFIER = com.selineren.WorldTrackerIOS;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "World Tracker";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -337,8 +338,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				EXECUTABLE_NAME = WorldTrackerIOS;
 				PRODUCT_BUNDLE_IDENTIFIER = com.selineren.WorldTrackerIOS;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "World Tracker";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;

--- a/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a1569f9895aa2be8e24832f98525d5da4eb90b5d158a82691c15b47eb72a13d7",
+  "originHash" : "fc056ca7916ed818ce8cf28eaf37caf5bd27786a890a91807960ad4069819601",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
         "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "145104f5ea9d58ae21b60add007c33c1cc0c948e",
+        "version" : "2.0.0"
       }
     },
     {
@@ -56,6 +65,15 @@
       }
     },
     {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "913b4005ea26aebe1c97d54e35ad82a515924c71",
+        "version" : "9.1.0"
+      }
+    },
+    {
       "identity" : "googleutilities",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
@@ -78,8 +96,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "a883ddb9fd464216133a5ab441f1ae8995978573",
-        "version" : "5.1.0"
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "56e0ccf09a6dd29dc7e68bdf729598240ca8aa16",
+        "version" : "5.0.0"
       }
     },
     {

--- a/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/xcshareddata/xcschemes/WorldTrackerIOS.xcscheme
+++ b/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/xcshareddata/xcschemes/WorldTrackerIOS.xcscheme
@@ -16,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "04ACF9D42F4E45E0004448FC"
-               BuildableName = "WorldTrackerIOS.app"
+               BuildableName = "World Tracker.app"
                BlueprintName = "WorldTrackerIOS"
                ReferencedContainer = "container:WorldTrackerIOS.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "04ACF9D42F4E45E0004448FC"
-            BuildableName = "WorldTrackerIOS.app"
+            BuildableName = "World Tracker.app"
             BlueprintName = "WorldTrackerIOS"
             ReferencedContainer = "container:WorldTrackerIOS.xcodeproj">
          </BuildableReference>
@@ -63,7 +63,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "04ACF9D42F4E45E0004448FC"
-            BuildableName = "WorldTrackerIOS.app"
+            BuildableName = "World Tracker.app"
             BlueprintName = "WorldTrackerIOS"
             ReferencedContainer = "container:WorldTrackerIOS.xcodeproj">
          </BuildableReference>

--- a/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import SwiftData
 import FirebaseCore
 import FirebaseAuth
+import GoogleSignIn
 import CoreText
 
 @main
@@ -82,6 +83,9 @@ struct WorldTrackerIOSApp: App {
                 .environmentObject(authService)
                 .task(id: authService.authState) {
                     await handleAuthStateChange()
+                }
+                .onOpenURL { url in
+                    GIDSignIn.sharedInstance.handle(url)
                 }
         }
         .modelContainer(container)

--- a/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
@@ -23,6 +23,11 @@ struct WorldTrackerIOSApp: App {
         Self.registerFonts()
         FirebaseApp.configure()
 
+        // Configure Google Sign-In with the client ID from GoogleService-Info.plist
+        if let clientID = FirebaseApp.app()?.options.clientID {
+            GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: clientID)
+        }
+
         do {
             // Create model configuration with migration options
             let schema = Schema([VisitEntity.self])

--- a/WorldTrackerIOS/WorldTrackerIOS/GoogleService-Info.plist
+++ b/WorldTrackerIOS/WorldTrackerIOS/GoogleService-Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>655684077710-fmlrh1kmripqvrgnv78n7ig6kuolf0v5.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.655684077710-fmlrh1kmripqvrgnv78n7ig6kuolf0v5</string>
+	<key>API_KEY</key>
+	<string>AIzaSyDYD3bIpEo_3RE3iOPrkROkvEC7W-LuNts</string>
+	<key>GCM_SENDER_ID</key>
+	<string>655684077710</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.selineren.WorldTrackerIOS</string>
+	<key>PROJECT_ID</key>
+	<string>worldtrackerios</string>
+	<key>STORAGE_BUCKET</key>
+	<string>worldtrackerios.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:655684077710:ios:c2a5739b0bf4c9a0cbe1df</string>
+</dict>
+</plist>

--- a/WorldTrackerIOS/WorldTrackerIOS/Info.plist
+++ b/WorldTrackerIOS/WorldTrackerIOS/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.655684077710-fmlrh1kmripqvrgnv78n7ig6kuolf0v5</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/WorldTrackerIOS/WorldTrackerIOS/Info.plist
+++ b/WorldTrackerIOS/WorldTrackerIOS/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>World Tracker</string>
+	<key>CFBundleName</key>
+	<string>World Tracker</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
@@ -8,6 +8,10 @@
 import Foundation
 import Combine
 import FirebaseAuth
+import GoogleSignIn
+import AuthenticationServices
+import CryptoKit
+import UIKit
 
 @MainActor
 final class AuthService: ObservableObject {
@@ -143,6 +147,94 @@ final class AuthService: ObservableObject {
         try Auth.auth().signOut()
     }
 
+    // MARK: - Google Sign-In
+
+    func signInWithGoogle() async throws {
+        guard let rootVC = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow })?.rootViewController else {
+            throw SocialAuthError.presentationError
+        }
+
+        let result = try await GIDSignIn.sharedInstance.signIn(withPresenting: rootVC)
+        guard let idToken = result.user.idToken?.tokenString else {
+            throw SocialAuthError.missingToken
+        }
+
+        let credential = GoogleAuthProvider.credential(
+            withIDToken: idToken,
+            accessToken: result.user.accessToken.tokenString
+        )
+        let authResult = try await Auth.auth().signIn(with: credential)
+
+        if authResult.additionalUserInfo?.isNewUser == true {
+            let profile = UserProfile(
+                userId: authResult.user.uid,
+                email: authResult.user.email ?? "",
+                firstName: result.user.profile?.givenName ?? "",
+                lastName: result.user.profile?.familyName ?? ""
+            )
+            try? await FirestoreUserRepository().createOrUpdateProfile(profile)
+        }
+    }
+
+    // MARK: - Apple Sign-In
+
+    private let appleCoordinator = AppleSignInCoordinator()
+    private var currentNonce: String?
+
+    func signInWithApple() async throws {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+
+        let provider = ASAuthorizationAppleIDProvider()
+        let request = provider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+
+        let authorization = try await appleCoordinator.signIn(with: request)
+
+        guard let appleCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let tokenData = appleCredential.identityToken,
+              let idToken = String(data: tokenData, encoding: .utf8),
+              let nonce = currentNonce else {
+            throw SocialAuthError.missingToken
+        }
+
+        let credential = OAuthProvider.appleCredential(
+            withIDToken: idToken,
+            rawNonce: nonce,
+            fullName: appleCredential.fullName
+        )
+        let authResult = try await Auth.auth().signIn(with: credential)
+
+        // Apple only provides name and email on the very first sign-in
+        if authResult.additionalUserInfo?.isNewUser == true {
+            let profile = UserProfile(
+                userId: authResult.user.uid,
+                email: appleCredential.email ?? authResult.user.email ?? "",
+                firstName: appleCredential.fullName?.givenName ?? "",
+                lastName: appleCredential.fullName?.familyName ?? ""
+            )
+            try? await FirestoreUserRepository().createOrUpdateProfile(profile)
+        }
+    }
+
+    // MARK: - Nonce helpers (required by Apple Sign-In)
+
+    private func randomNonceString(length: Int = 32) -> String {
+        var randomBytes = [UInt8](repeating: 0, count: length)
+        SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        let charset = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        return String(randomBytes.map { charset[Int($0) % charset.count] })
+    }
+
+    private func sha256(_ input: String) -> String {
+        let hash = SHA256.hash(data: Data(input.utf8))
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
+
     /// Reauthenticate the current user with their password
     /// Required by Firebase before sensitive operations like password changes
     func reauthenticate(currentPassword: String) async throws {
@@ -216,13 +308,63 @@ enum AuthState: Equatable, CustomStringConvertible {
     case unknown
     case signedIn
     case signedOut
-    
+
     var description: String {
         switch self {
         case .unknown: return ".unknown"
         case .signedIn: return ".signedIn"
         case .signedOut: return ".signedOut"
         }
+    }
+}
+
+enum SocialAuthError: LocalizedError {
+    case missingToken
+    case presentationError
+
+    var errorDescription: String? {
+        switch self {
+        case .missingToken:       return "Sign-in failed. Please try again."
+        case .presentationError:  return "Could not present the sign-in screen."
+        }
+    }
+}
+
+// MARK: - Apple Sign-In Coordinator
+
+private final class AppleSignInCoordinator: NSObject,
+    ASAuthorizationControllerDelegate,
+    ASAuthorizationControllerPresentationContextProviding
+{
+    private var continuation: CheckedContinuation<ASAuthorization, Error>?
+
+    func signIn(with request: ASAuthorizationAppleIDRequest) async throws -> ASAuthorization {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            controller.performRequests()
+        }
+    }
+
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow } ?? UIWindow()
+    }
+
+    func authorizationController(controller: ASAuthorizationController,
+                                 didCompleteWithAuthorization authorization: ASAuthorization) {
+        continuation?.resume(returning: authorization)
+        continuation = nil
+    }
+
+    func authorizationController(controller: ASAuthorizationController,
+                                 didCompleteWithError error: Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
     }
 }
 

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
@@ -18,6 +18,7 @@ struct AuthScreen: View {
     @State private var isCreatingAccount = false
     @State private var errorMessage: String?
     @State private var isSubmitting = false
+    @State private var isSocialSubmitting = false
     @State private var showPassword = false
 
     var body: some View {
@@ -186,10 +187,14 @@ struct AuthScreen: View {
                 VStack(spacing: 12) {
                     // Google
                     Button {
-                        // TODO: Google sign-in
+                        Task { await submitSocial { try await authService.signInWithGoogle() } }
                     } label: {
                         HStack(spacing: 12) {
-                            GoogleLogoView()
+                            if isSocialSubmitting {
+                                ProgressView().tint(.black)
+                            } else {
+                                GoogleLogoView()
+                            }
                             Text("Continue with Google")
                                 .font(.custom("Inter", size: 16))
                                 .fontWeight(.semibold)
@@ -200,25 +205,12 @@ struct AuthScreen: View {
                         .background(Color(hex: "#F5F5F5"))
                         .clipShape(Capsule())
                     }
+                    .disabled(isSocialSubmitting || isSubmitting)
 
-                    // Apple
-                    Button {
-                        // TODO: Apple sign-in
-                    } label: {
-                        HStack(spacing: 12) {
-                            Image(systemName: "apple.logo")
-                                .font(.system(size: 18, weight: .medium))
-                                .foregroundStyle(.black)
-                            Text("Continue with Apple")
-                                .font(.custom("Inter", size: 16))
-                                .fontWeight(.semibold)
-                                .foregroundStyle(.black)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 52)
-                        .background(Color(hex: "#F5F5F5"))
-                        .clipShape(Capsule())
-                    }
+                    // Apple (requires paid Apple Developer account — hidden until enrolled)
+                    // Button {
+                    //     Task { await submitSocial { try await authService.signInWithApple() } }
+                    // } label: { ... }
                 }
                 .padding(.horizontal, 24)
                 .padding(.top, 24)
@@ -258,6 +250,19 @@ struct AuthScreen: View {
             return base && !firstName.isEmpty && !lastName.isEmpty
         }
         return base
+    }
+
+    private func submitSocial(_ action: () async throws -> Void) async {
+        errorMessage = nil
+        isSocialSubmitting = true
+        defer { isSocialSubmitting = false }
+        do {
+            try await action()
+        } catch {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                errorMessage = friendlyErrorMessage(from: error)
+            }
+        }
     }
 
     private func submit() async {


### PR DESCRIPTION
Summary                                                                                           
                                                                                                    
  - Added Google Sign-In via the GoogleSignIn-iOS Swift Package + Firebase Auth                     
  - New users get a Firestore profile created automatically on first sign-in (name + email pulled   
  from their Google account)                                                                        
  - Fixed crash on tap — GIDSignIn requires a GIDConfiguration to be set before                     
  signIn(withPresenting:) is called; added this to app init                                         
  - Fixed app name showing as "WorldTrackerIOS" in the Google sign-in dialog — set PRODUCT_NAME =   
  "World Tracker" with EXECUTABLE_NAME pinned so the binary name is unchanged                       
  - Apple Sign-In logic is implemented in AuthService but the button is hidden — requires a paid    
  Apple Developer account to activate the Xcode capability                                          
                                                                                                    
  What was set up manually                                                                          
                                                                                                    
  - Google Sign-In enabled in Firebase Console                                                    
  - GoogleService-Info.plist updated with the new config                                            
  - REVERSED_CLIENT_ID added as a URL scheme in Xcode                                             
  - GoogleSignIn-iOS package added via Swift Package Dependencies                                   
  - OAuth consent screen app name updated in Google Cloud Console
                                                                                                    
  Test plan                               
                                                                                                    
  - Tap "Continue with Google" — account picker appears without crashing                            
  - First Google sign-in creates a Firestore profile                                                
  - Returning Google user signs in without creating a duplicate profile                             
  - Sign-in dialog shows "World Tracker" not "WorldTrackerIOS"                                      
  - Email/password sign-in still works normally
  - Cancelling the Google sheet shows no error