### PR TITLE
feat: redesign map colors, legend and bitmoji circles

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/DesignSystem/AppColors.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/DesignSystem/AppColors.swift
@@ -17,13 +17,13 @@ extension Color {
     // MARK: Borders
     static let appLine   = Color(hex: "#E2E2E2")
 
-    // MARK: Visited (red — matches map fill)
-    static let appVisited    = Color(hex: "#F9234D")
-    static let appVisitedBg  = Color(hex: "#FFF0F5")
+    // MARK: Visited (cherry red — matches map fill)
+    static let appVisited    = Color(hex: "#DC2626")
+    static let appVisitedBg  = Color(hex: "#FEF2F2")
 
-    // MARK: Wishlist (sky blue — matches map fill)
-    static let appWishlist   = Color(hex: "#4A90D9")
-    static let appWishlistBg = Color(hex: "#EAF6FE")
+    // MARK: Wishlist (vivid violet — matches map fill)
+    static let appWishlist   = Color(hex: "#7C3AED")
+    static let appWishlistBg = Color(hex: "#F5F3FF")
 
     // MARK: Achievement (gold)
     static let appGold   = Color(hex: "#E6A817")

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/CountryMapBitmoji.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/CountryMapBitmoji.swift
@@ -57,30 +57,30 @@ class CountryBitmojiAnnotationView: MKAnnotationView {
     
     private let noteIconView: UIView = {
         let container = UIView()
-        container.backgroundColor = .systemBlue
+        container.backgroundColor = .white
         container.layer.cornerRadius = 16
         container.layer.borderWidth = 3.0
         container.layer.borderColor = UIColor.white.cgColor
-        
+
         let icon = UIImageView(image: UIImage(systemName: "note.text"))
-        icon.tintColor = .white
+        icon.tintColor = .darkGray
         icon.contentMode = .scaleAspectFit
         icon.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(icon)
-        
+
         NSLayoutConstraint.activate([
             icon.centerXAnchor.constraint(equalTo: container.centerXAnchor),
             icon.centerYAnchor.constraint(equalTo: container.centerYAnchor),
             icon.widthAnchor.constraint(equalToConstant: 16),
             icon.heightAnchor.constraint(equalToConstant: 16)
         ])
-        
+
         return container
     }()
     
     private let flagView: UIView = {
         let container = UIView()
-        container.backgroundColor = .systemGreen
+        container.backgroundColor = .white
         container.layer.cornerRadius = 16
         container.layer.borderWidth = 3.0
         container.layer.borderColor = UIColor.white.cgColor

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -366,7 +366,7 @@ struct MapScreen: View {
                 if filterMode == .all || filterMode == .visited {
                     HStack(spacing: 8) {
                         Circle()
-                            .fill(Color(hex: "#F9234D"))
+                            .fill(Color.appVisited)
                             .frame(width: 10, height: 10)
                         Text("VISITED")
                             .font(.system(size: 10, weight: .black))
@@ -378,7 +378,7 @@ struct MapScreen: View {
                 if filterMode == .all || filterMode == .wishlist {
                     HStack(spacing: 8) {
                         Circle()
-                            .fill(Color(hex: "#93E0FA"))
+                            .fill(Color.appWishlist)
                             .frame(width: 10, height: 10)
                         Text("WISHLIST")
                             .font(.system(size: 10, weight: .black))

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
@@ -372,12 +372,12 @@ struct VisitedCountriesMapView: UIViewRepresentable {
             let countryID = countryID(for: overlay)
 
             if let countryID, visitedCountryIDs.contains(countryID) {
-                renderer.fillColor = UIColor(red: 0.976, green: 0.137, blue: 0.302, alpha: 0.7)
-                renderer.strokeColor = UIColor(red: 0.976, green: 0.137, blue: 0.302, alpha: 0.9)
+                renderer.fillColor = UIColor(red: 0.863, green: 0.149, blue: 0.149, alpha: 0.75)
+                renderer.strokeColor = UIColor(red: 0.863, green: 0.149, blue: 0.149, alpha: 0.95)
                 renderer.lineWidth = 1.5
             } else if let countryID, wantToVisitCountryIDs.contains(countryID) {
-                renderer.fillColor = UIColor(red: 0.576, green: 0.878, blue: 0.980, alpha: 0.7)
-                renderer.strokeColor = UIColor(red: 0.576, green: 0.878, blue: 0.980, alpha: 0.9)
+                renderer.fillColor = UIColor(red: 0.486, green: 0.227, blue: 0.929, alpha: 0.65)
+                renderer.strokeColor = UIColor(red: 0.486, green: 0.227, blue: 0.929, alpha: 0.9)
                 renderer.lineWidth = 1.2
             } else {
                 renderer.fillColor = UIColor.systemGray5.withAlphaComponent(0.85)


### PR DESCRIPTION
Summary                                                                                        
  - Visited countries now render in cherry red (#DC2626) — strong contrast against the ocean blue background                                                                                        
  - Wishlist countries now render in vivid violet (#7C3AED) — distinct from both ocean and visited  
  - Map legend dots updated to use AppColors design tokens so they stay in sync automatically       
  - Bitmoji annotation circles changed from colored (green/blue) backgrounds to white