### PR TITLE
feat: forgot password flow

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/AuthService.swift
@@ -147,6 +147,10 @@ final class AuthService: ObservableObject {
         try Auth.auth().signOut()
     }
 
+    func sendPasswordReset(email: String) async throws {
+        try await Auth.auth().sendPasswordReset(withEmail: email)
+    }
+
     // MARK: - Google Sign-In
 
     func signInWithGoogle() async throws {

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
@@ -20,6 +20,8 @@ struct AuthScreen: View {
     @State private var isSubmitting = false
     @State private var isSocialSubmitting = false
     @State private var showPassword = false
+    @State private var showResetConfirmation = false
+    @State private var isSendingReset = false
 
     var body: some View {
         ScrollView {
@@ -156,14 +158,27 @@ struct AuthScreen: View {
                 // MARK: - Forgot Password
                 if !isCreatingAccount {
                     Button {
-                        // TODO: forgot password flow
+                        Task { await sendPasswordReset() }
                     } label: {
-                        Text("Forgot password?")
-                            .font(.custom("Inter", size: 14))
-                            .fontWeight(.bold)
-                            .foregroundStyle(Color(hex: "#6B6B6B"))
+                        HStack(spacing: 6) {
+                            if isSendingReset {
+                                ProgressView()
+                                    .scaleEffect(0.75)
+                                    .tint(Color(hex: "#6B6B6B"))
+                            }
+                            Text("Forgot password?")
+                                .font(.custom("Inter", size: 14))
+                                .fontWeight(.bold)
+                                .foregroundStyle(Color(hex: "#6B6B6B"))
+                        }
                     }
+                    .disabled(isSendingReset || isSubmitting)
                     .padding(.top, 20)
+                    .alert("Check your inbox", isPresented: $showResetConfirmation) {
+                        Button("OK", role: .cancel) { }
+                    } message: {
+                        Text("We sent a password reset link to \(email).")
+                    }
                 }
 
                 // MARK: - OR Divider
@@ -261,6 +276,25 @@ struct AuthScreen: View {
         } catch {
             withAnimation(.easeInOut(duration: 0.3)) {
                 errorMessage = friendlyErrorMessage(from: error)
+            }
+        }
+    }
+
+    private func sendPasswordReset() async {
+        guard !email.isEmpty else {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                errorMessage = "Enter your email address above to reset your password"
+            }
+            return
+        }
+        isSendingReset = true
+        defer { isSendingReset = false }
+        do {
+            try await authService.sendPasswordReset(email: email)
+            showResetConfirmation = true
+        } catch {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                errorMessage = "Couldn't send reset email. Check the address and try again."
             }
         }
     }


### PR DESCRIPTION
Summary
  - Wires up the previously stubbed "Forgot password?" button on the sign-in screen                                           
  - Sends a Firebase password reset email using `Auth.auth().sendPasswordReset`                                   
  - Shows a loading spinner on the button while the request is in flight                                                            
  - Displays a success alert ("Check your inbox") with the target email on success                                                  
  - Shows an inline error if the email field is empty or the request fails                                                            
                                                           
Test plan                                                      
  - [ ] Enter a registered email, tap "Forgot password?" → success alert appears, reset email arrives (check spam if needed)         
  - [ ] Leave email empty, tap button → inline error prompts user to enter email first                                                
  - [ ] Enter malformed email → error shown                 
  - [ ] Button is disabled and shows spinner during sending         
  - [ ] Button is hidden on the sign-up screen