### PR TITLE
feat: implement full dark mode support

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
@@ -37,20 +37,20 @@ struct WorldTrackerIOSApp: App {
                 allowsSave: true,
                 cloudKitDatabase: .none
             )
-            
+
             container = try ModelContainer(
                 for: schema,
                 configurations: [modelConfiguration]
             )
             let context = ModelContext(container)
-            
+
             let localRepo = SwiftDataVisitRepository(context: context)
             let cloudRepo = FirestoreVisitRepository()
             let syncService = SyncService(
                 localRepository: localRepo,
                 cloudRepository: cloudRepo
             )
-            
+
             _appState = StateObject(
                 wrappedValue: AppState(
                     repository: localRepo,
@@ -95,36 +95,28 @@ struct WorldTrackerIOSApp: App {
         }
         .modelContainer(container)
     }
-    
+
     @MainActor
     private func handleAuthStateChange() async {
         switch authService.authState {
         case .signedIn:
-            // User signed in - load data and sync
             await appState.handleSignIn()
         case .signedOut:
-            // User signed out - clear data
             appState.handleSignOut()
         case .unknown:
-            // Initial state - do nothing
             break
         }
     }
 }
 // MARK: - Auth-Gated Root View
 
-/// Root view that conditionally shows authentication or main app content
-/// based on the user's sign-in status.
 struct AuthGatedRootView: View {
     @EnvironmentObject private var authService: AuthService
-    
+
     var body: some View {
         Group {
             switch authService.authState {
             case .signedIn:
-                // User is authenticated - show main app
-                // Use signInCounter to force recreation on each sign-in
-                // This ensures tab selection is reset to Map every time
                 RootTabView()
                     .id("signed-in-\(authService.signInCounter)")
                     .transition(.opacity)
@@ -133,9 +125,8 @@ struct AuthGatedRootView: View {
                         print("📱 Showing RootTabView (signed in)")
                         #endif
                     }
-                
+
             case .signedOut:
-                // User is not authenticated - show auth screen
                 AuthScreen()
                     .transition(.opacity)
                     .onAppear {
@@ -143,9 +134,8 @@ struct AuthGatedRootView: View {
                         print("📱 Showing AuthScreen (signed out)")
                         #endif
                     }
-                
+
             case .unknown:
-                // Initial state - show loading screen while Firebase checks session
                 LoadingView()
                     .transition(.opacity)
                     .onAppear {
@@ -160,11 +150,10 @@ struct AuthGatedRootView: View {
 }
 
 // MARK: - Loading View
-/// Displayed during initial app launch while Firebase checks authentication status
 private struct LoadingView: View {
     var body: some View {
         ZStack {
-            Color.white
+            Color.appPaper
                 .ignoresSafeArea()
 
             VStack(spacing: 32) {
@@ -174,7 +163,7 @@ private struct LoadingView: View {
                     .font(.custom("Inter", size: 16))
                     .fontWeight(.black)
                     .tracking(4)
-                    .foregroundStyle(.black)
+                    .foregroundStyle(Color.appInk)
 
                 LoadingSpinner()
                     .padding(.top, 48)
@@ -200,7 +189,7 @@ private struct LoadingSpinner: View {
     var body: some View {
         Circle()
             .trim(from: 0.1, to: 0.9)
-            .stroke(Color.black, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+            .stroke(Color.appInk, style: StrokeStyle(lineWidth: 2, lineCap: .round))
             .frame(width: 24, height: 24)
             .rotationEffect(.degrees(rotation))
             .onAppear {
@@ -210,5 +199,3 @@ private struct LoadingSpinner: View {
             }
     }
 }
-
-

--- a/WorldTrackerIOS/WorldTrackerIOS/DesignSystem/AppColors.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/DesignSystem/AppColors.swift
@@ -1,40 +1,57 @@
 import SwiftUI
 
-// MARK: - Color tokens
+// MARK: - Adaptive Color Tokens
 
 extension Color {
 
     // MARK: Surfaces
-    static let appPaper  = Color(hex: "#F7F7F7")
-    static let appPaper2 = Color(hex: "#F3F3F3")
-    static let appCard   = Color.white
+    static let appPaper  = Color(UIColor { tc in
+        tc.userInterfaceStyle == .dark ? UIColor(hex: "#1A1A1A") : UIColor(hex: "#F7F7F7")
+    })
+    static let appPaper2 = Color(UIColor { tc in
+        tc.userInterfaceStyle == .dark ? UIColor(hex: "#2A2A2A") : UIColor(hex: "#F3F3F3")
+    })
+    static let appCard = Color(UIColor.secondarySystemGroupedBackground)
 
     // MARK: Ink / Text
-    static let appInk    = Color(hex: "#1b1b1b")
-    static let appInk2   = Color(hex: "#6B6B6B")
-    static let appInk3   = Color(hex: "#9E9E9E")
+    static let appInk  = Color(UIColor.label)
+    static let appInk2 = Color(UIColor.secondaryLabel)
+    static let appInk3 = Color(UIColor.tertiaryLabel)
 
-    // MARK: Borders
-    static let appLine   = Color(hex: "#E2E2E2")
+    // MARK: Borders / Dividers
+    static let appLine = Color(UIColor.separator)
+
+    // MARK: Intentional dark surface (hero cards, CTAs) — elevated in dark mode
+    static let appSurface = Color(UIColor { tc in
+        tc.userInterfaceStyle == .dark ? UIColor(hex: "#2C2C2E") : UIColor(hex: "#111111")
+    })
 
     // MARK: Visited (cherry red — matches map fill)
-    static let appVisited    = Color(hex: "#DC2626")
-    static let appVisitedBg  = Color(hex: "#FEF2F2")
+    static let appVisited   = Color(hex: "#DC2626")
+    static let appVisitedBg = Color(UIColor { tc in
+        tc.userInterfaceStyle == .dark ? UIColor(hex: "#3D1515") : UIColor(hex: "#FEF2F2")
+    })
 
     // MARK: Wishlist (vivid violet — matches map fill)
     static let appWishlist   = Color(hex: "#7C3AED")
-    static let appWishlistBg = Color(hex: "#F5F3FF")
+    static let appWishlistBg = Color(UIColor { tc in
+        tc.userInterfaceStyle == .dark ? UIColor(hex: "#2D1B4E") : UIColor(hex: "#F5F3FF")
+    })
 
     // MARK: Achievement (gold)
     static let appGold   = Color(hex: "#E6A817")
-    static let appGoldBg = Color(hex: "#FFF9E6")
+    static let appGoldBg = Color(UIColor { tc in
+        tc.userInterfaceStyle == .dark ? UIColor(hex: "#3D2D0A") : UIColor(hex: "#FFF9E6")
+    })
 
     // MARK: Success / confirmed (green)
     static let appSuccess   = Color(hex: "#2E9E5B")
-    static let appSuccessBg = Color(hex: "#F0FFF4")
+    static let appSuccessBg = Color(UIColor { tc in
+        tc.userInterfaceStyle == .dark ? UIColor(hex: "#0D3320") : UIColor(hex: "#F0FFF4")
+    })
 }
 
-// MARK: - Hex initializer
+// MARK: - Hex initializer (SwiftUI Color)
 extension Color {
     init(hex: String) {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
@@ -42,14 +59,10 @@ extension Color {
         Scanner(string: hex).scanHexInt64(&int)
         let a, r, g, b: UInt64
         switch hex.count {
-        case 3:
-            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
-        case 6:
-            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-        case 8:
-            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
-        default:
-            (a, r, g, b) = (255, 0, 0, 0)
+        case 3:  (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6:  (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8:  (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default: (a, r, g, b) = (255, 0, 0, 0)
         }
         self.init(
             .sRGB,
@@ -57,6 +70,28 @@ extension Color {
             green:   Double(g) / 255,
             blue:    Double(b) / 255,
             opacity: Double(a) / 255
+        )
+    }
+}
+
+// MARK: - Hex initializer (UIColor — used in dynamic color providers above)
+extension UIColor {
+    convenience init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3:  (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6:  (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8:  (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default: (a, r, g, b) = (255, 0, 0, 0)
+        }
+        self.init(
+            red:   Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            alpha: Double(a) / 255
         )
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/ChangePasswordView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/ChangePasswordView.swift
@@ -54,16 +54,15 @@ struct ChangePasswordView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
             HStack {
                 Text("Change Password")
                     .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                 Spacer()
                 Button { dismiss() } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 26))
-                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 .buttonStyle(.plain)
                 .disabled(isSubmitting)
@@ -79,7 +78,7 @@ struct ChangePasswordView: View {
                     VStack(alignment: .leading, spacing: 10) {
                         Text("VERIFY IDENTITY")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                             .tracking(0.8)
                             .padding(.horizontal, 4)
 
@@ -90,13 +89,13 @@ struct ChangePasswordView: View {
                                 show: $showCurrent
                             )
                         }
-                        .background(Color.white)
+                        .background(Color.appCard)
                         .clipShape(RoundedRectangle(cornerRadius: 14))
                         .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
 
                         Text("Enter your current password to continue")
                             .font(.system(size: 12))
-                            .foregroundStyle(Color(hex: "#BBBBBB"))
+                            .foregroundStyle(Color.appInk3)
                             .padding(.horizontal, 4)
                     }
 
@@ -104,7 +103,7 @@ struct ChangePasswordView: View {
                     VStack(alignment: .leading, spacing: 10) {
                         Text("NEW PASSWORD")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                             .tracking(0.8)
                             .padding(.horizontal, 4)
 
@@ -129,22 +128,22 @@ struct ChangePasswordView: View {
                                 HStack(spacing: 8) {
                                     Image(systemName: passwordsMatch ? "checkmark.circle.fill" : "xmark.circle.fill")
                                         .font(.system(size: 15))
-                                        .foregroundStyle(passwordsMatch ? Color(hex: "#2E9E5B") : Color(hex: "#CCCCCC"))
+                                        .foregroundStyle(passwordsMatch ? Color.appSuccess : Color.appInk3)
                                     Text(passwordsMatch ? "Passwords match" : (validationHint ?? "Passwords do not match"))
                                         .font(.system(size: 13))
-                                        .foregroundStyle(passwordsMatch ? Color(hex: "#2E9E5B") : Color(hex: "#9E9E9E"))
+                                        .foregroundStyle(passwordsMatch ? Color.appSuccess : Color.appInk3)
                                 }
                                 .padding(.horizontal, 16)
                                 .padding(.vertical, 14)
                             }
                         }
-                        .background(Color.white)
+                        .background(Color.appCard)
                         .clipShape(RoundedRectangle(cornerRadius: 14))
                         .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
 
                         Text("Password must be at least 6 characters")
                             .font(.system(size: 12))
-                            .foregroundStyle(Color(hex: "#BBBBBB"))
+                            .foregroundStyle(Color.appInk3)
                             .padding(.horizontal, 4)
                     }
 
@@ -172,7 +171,7 @@ struct ChangePasswordView: View {
                             }
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 18)
-                            .background(isFormValid ? Color(hex: "#1b1b1b") : Color(hex: "#CCCCCC"))
+                            .background(isFormValid ? Color.appSurface : Color.appLine)
                             .clipShape(Capsule())
                         }
                         .buttonStyle(.plain)
@@ -181,7 +180,7 @@ struct ChangePasswordView: View {
                         Button { dismiss() } label: {
                             Text("Cancel")
                                 .font(.system(size: 15))
-                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                                .foregroundStyle(Color.appInk3)
                         }
                         .buttonStyle(.plain)
                         .disabled(isSubmitting)
@@ -191,7 +190,7 @@ struct ChangePasswordView: View {
                 .padding(.bottom, 32)
             }
         }
-        .background(Color(hex: "#F7F7F7"))
+        .background(Color.appPaper)
     }
 
     // MARK: - Password Field
@@ -206,7 +205,7 @@ struct ChangePasswordView: View {
                 }
             }
             .font(.system(size: 15))
-            .foregroundStyle(Color(hex: "#1b1b1b"))
+            .foregroundStyle(Color.appInk)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
 
@@ -215,7 +214,7 @@ struct ChangePasswordView: View {
             } label: {
                 Image(systemName: show.wrappedValue ? "eye.fill" : "eye.slash.fill")
                     .font(.system(size: 16))
-                    .foregroundStyle(show.wrappedValue ? Color(hex: "#6B6B6B") : Color(hex: "#CCCCCC"))
+                    .foregroundStyle(show.wrappedValue ? Color.appInk2 : Color.appInk3)
             }
             .buttonStyle(.plain)
         }

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/ComparisonView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/ComparisonView.swift
@@ -18,7 +18,7 @@ struct ComparisonView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color(hex: "#F7F7F7").ignoresSafeArea()
+                Color.appPaper.ignoresSafeArea()
                 switch viewModel.state {
                 case .idle:
                     searchView
@@ -38,7 +38,7 @@ struct ComparisonView: View {
                         Button { viewModel.resetToIdle() } label: {
                             Image(systemName: "chevron.left")
                                 .font(.system(size: 16, weight: .semibold))
-                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                                .foregroundStyle(Color.appInk)
                         }
                     }
                 }
@@ -75,16 +75,16 @@ struct ComparisonView: View {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("FRIEND'S EMAIL")
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                         .tracking(0.8)
 
                     HStack(spacing: 12) {
                         Image(systemName: "envelope")
                             .font(.system(size: 15))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                         TextField("friend@example.com", text: $viewModel.emailToCompare)
                             .font(.system(size: 15))
-                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .foregroundStyle(Color.appInk)
                             .textInputAutocapitalization(.never)
                             .keyboardType(.emailAddress)
                             .autocorrectionDisabled()
@@ -95,7 +95,7 @@ struct ComparisonView: View {
                     }
                     .padding(.horizontal, 16)
                     .frame(height: 50)
-                    .background(Color(hex: "#F3F3F3"))
+                    .background(Color.appPaper2)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
 
                     Button {
@@ -106,14 +106,14 @@ struct ComparisonView: View {
                             .foregroundStyle(.white)
                             .frame(maxWidth: .infinity)
                             .frame(height: 52)
-                            .background(Color(hex: "#1b1b1b"))
+                            .background(Color.appSurface)
                             .clipShape(RoundedRectangle(cornerRadius: 10))
                     }
                     .disabled(viewModel.emailToCompare.isEmpty)
                     .opacity(viewModel.emailToCompare.isEmpty ? 0.5 : 1)
                 }
                 .padding(16)
-                .background(Color.white)
+                .background(Color.appCard)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
                 .padding(.horizontal, 16)
@@ -125,7 +125,7 @@ struct ComparisonView: View {
                         .font(.system(size: 12))
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                .foregroundStyle(Color(hex: "#9E9E9E"))
+                .foregroundStyle(Color.appInk3)
                 .padding(.horizontal, 24)
                 .padding(.bottom, 32)
             }
@@ -135,8 +135,8 @@ struct ComparisonView: View {
     private var heroEntryCard: some View {
         VStack(alignment: .leading, spacing: 20) {
             HStack(spacing: -12) {
-                avatarCircle(initials: myInitials, bg: Color(hex: "#3A3A3A"))
-                avatarCircle(initials: "?", bg: Color(hex: "#1b1b1b"))
+                avatarCircle(initials: myInitials, bg: Color.appSurface.opacity(0.7))
+                avatarCircle(initials: "?", bg: Color.appSurface)
             }
             VStack(alignment: .leading, spacing: 8) {
                 Text("Compare your travels\nwith anyone")
@@ -150,7 +150,7 @@ struct ComparisonView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)
-        .background(Color(hex: "#1b1b1b"))
+        .background(Color.appSurface)
         .clipShape(RoundedRectangle(cornerRadius: 18))
     }
 
@@ -162,7 +162,7 @@ struct ComparisonView: View {
                 .scaleEffect(1.3)
             Text("Loading comparison...")
                 .font(.system(size: 14))
-                .foregroundStyle(Color(hex: "#9E9E9E"))
+                .foregroundStyle(Color.appInk3)
         }
     }
 
@@ -185,7 +185,7 @@ struct ComparisonView: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding(24)
-                .background(Color(hex: "#1b1b1b"))
+                .background(Color.appSurface)
                 .clipShape(RoundedRectangle(cornerRadius: 18))
                 .padding(.horizontal, 16)
                 .padding(.top, 20)
@@ -196,7 +196,7 @@ struct ComparisonView: View {
                         .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
                         .frame(height: 52)
-                        .background(Color(hex: "#1b1b1b"))
+                        .background(Color.appSurface)
                         .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
                 .padding(.horizontal, 16)
@@ -223,7 +223,6 @@ struct ComparisonView: View {
                         .padding(.top, 16)
                 }
 
-                // Mode chips
                 HStack(spacing: 8) {
                     modeChip("Visited", mode: .visited)
                     modeChip("Wishlist", mode: .wishlist)
@@ -234,7 +233,7 @@ struct ComparisonView: View {
                 if viewModel.currentComparison.totalUnique == 0 {
                     Text("No \(viewModel.selectedMode == .visited ? "visited" : "wishlisted") countries to compare")
                         .font(.system(size: 14))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                         .frame(maxWidth: .infinity)
                         .padding(.top, 32)
                         .padding(.horizontal, 32)
@@ -271,29 +270,25 @@ struct ComparisonView: View {
         let friendName = friendShortName(from: profile)
 
         return VStack(alignment: .leading, spacing: 16) {
-            // Top row: avatars + email pill
             HStack(alignment: .center) {
                 HStack(spacing: -14) {
-                    // Your avatar: white circle, dark text
                     Text(myInitials)
                         .font(.system(size: 15, weight: .bold))
-                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .foregroundStyle(Color.appInk)
                         .frame(width: 44, height: 44)
-                        .background(Color.white)
+                        .background(Color.appCard)
                         .clipShape(Circle())
-                    // Friend's avatar: blue circle, white text
                     Text(friendInitials(from: profile))
                         .font(.system(size: 15, weight: .bold))
                         .foregroundStyle(.white)
                         .frame(width: 44, height: 44)
                         .background(Color(hex: "#6C8EFF"))
                         .clipShape(Circle())
-                        .overlay(Circle().stroke(Color(hex: "#1b1b1b"), lineWidth: 2))
+                        .overlay(Circle().stroke(Color.appSurface, lineWidth: 2))
                 }
 
                 Spacer()
 
-                // Email pill
                 Text(profile.email)
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(Color.white.opacity(0.85))
@@ -304,7 +299,6 @@ struct ComparisonView: View {
                     .clipShape(Capsule())
             }
 
-            // "YOU & JOHN" label + big title
             VStack(alignment: .leading, spacing: 6) {
                 Text("YOU & \(friendName.uppercased())")
                     .font(.system(size: 12, weight: .semibold))
@@ -318,12 +312,10 @@ struct ComparisonView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            // Divider
             Rectangle()
                 .fill(Color.white.opacity(0.15))
                 .frame(height: 1)
 
-            // Stats row
             HStack(spacing: 0) {
                 statColumn(value: "\(sharedCount)", label: "Together")
                 Rectangle().fill(Color.white.opacity(0.15)).frame(width: 1, height: 44)
@@ -334,7 +326,7 @@ struct ComparisonView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)
-        .background(Color(hex: "#111111"))
+        .background(Color.appSurface)
         .clipShape(RoundedRectangle(cornerRadius: 20))
     }
 
@@ -354,19 +346,19 @@ struct ComparisonView: View {
         HStack(spacing: 14) {
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(Color(hex: "#F3F3F3"))
+                    .fill(Color.appInk.opacity(0.06))
                     .frame(width: 44, height: 44)
                 Image(systemName: "mappin.and.ellipse")
                     .font(.system(size: 18))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
             }
             VStack(alignment: .leading, spacing: 2) {
                 Text("Plan a trip together")
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                 Text("\(matchCount) wishlist \(matchCount == 1 ? "match" : "matches")")
                     .font(.system(size: 13))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
             }
             Spacer()
             Button {
@@ -377,12 +369,12 @@ struct ComparisonView: View {
                     .foregroundStyle(.white)
                     .padding(.horizontal, 18)
                     .padding(.vertical, 9)
-                    .background(Color(hex: "#1b1b1b"))
+                    .background(Color.appSurface)
                     .clipShape(Capsule())
             }
         }
         .padding(14)
-        .background(Color.white)
+        .background(Color.appCard)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
     }
@@ -391,12 +383,12 @@ struct ComparisonView: View {
         Button { viewModel.selectedMode = mode } label: {
             Text(title)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(viewModel.selectedMode == mode ? .white : Color(hex: "#6B6B6B"))
+                .foregroundStyle(viewModel.selectedMode == mode ? .white : Color.appInk2)
                 .padding(.horizontal, 18)
                 .padding(.vertical, 8)
-                .background(viewModel.selectedMode == mode ? Color(hex: "#1b1b1b") : Color.white)
+                .background(viewModel.selectedMode == mode ? Color.appSurface : Color.appCard)
                 .clipShape(Capsule())
-                .overlay(Capsule().stroke(viewModel.selectedMode == mode ? Color.clear : Color(hex: "#E2E2E2"), lineWidth: 1))
+                .overlay(Capsule().stroke(viewModel.selectedMode == mode ? Color.clear : Color.appLine, lineWidth: 1))
         }
         .buttonStyle(.plain)
     }
@@ -405,7 +397,7 @@ struct ComparisonView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text(label)
                 .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(Color(hex: "#9E9E9E"))
+                .foregroundStyle(Color.appInk3)
                 .tracking(0.8)
                 .padding(.horizontal, 16)
 
@@ -420,7 +412,7 @@ struct ComparisonView: View {
                                 .frame(width: 40, height: 36)
                             Text(country.name)
                                 .font(.system(size: 16, weight: .semibold))
-                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                                .foregroundStyle(Color.appInk)
                             Spacer()
                             Text(badge.label)
                                 .font(.system(size: 10, weight: .bold))
@@ -431,11 +423,11 @@ struct ComparisonView: View {
                                 .clipShape(RoundedRectangle(cornerRadius: 6))
                             Image(systemName: "chevron.right")
                                 .font(.system(size: 12, weight: .semibold))
-                                .foregroundStyle(Color(hex: "#CCCCCC"))
+                                .foregroundStyle(Color.appInk3)
                         }
                         .padding(.horizontal, 16)
                         .padding(.vertical, 14)
-                        .background(Color.white)
+                        .background(Color.appCard)
                         .clipShape(RoundedRectangle(cornerRadius: 14))
                         .shadow(color: .black.opacity(0.03), radius: 4, x: 0, y: 1)
                     }
@@ -455,7 +447,7 @@ struct ComparisonView: View {
             .frame(width: 38, height: 38)
             .background(bg)
             .clipShape(Circle())
-            .overlay(Circle().stroke(Color(hex: "#1b1b1b"), lineWidth: 2))
+            .overlay(Circle().stroke(Color.appSurface, lineWidth: 2))
     }
 
     private var myInitials: String {
@@ -516,7 +508,7 @@ enum ComparisonBadge {
     var pillForeground: Color {
         switch self {
         case .yours:   return Color(hex: "#1E7F4E")
-        case .shared:  return Color(hex: "#1b1b1b")
+        case .shared:  return Color.appInk
         case .theirs:  return Color(hex: "#9E4E00")
         }
     }
@@ -524,7 +516,7 @@ enum ComparisonBadge {
     var pillBackground: Color {
         switch self {
         case .yours:   return Color(hex: "#1E7F4E").opacity(0.1)
-        case .shared:  return Color(hex: "#1b1b1b").opacity(0.08)
+        case .shared:  return Color.appInk.opacity(0.08)
         case .theirs:  return Color(hex: "#F37826").opacity(0.15)
         }
     }
@@ -534,8 +526,6 @@ enum ComparisonBadge {
 
 @MainActor
 final class ComparisonViewModel: ObservableObject {
-    // MARK: - State Management
-
     enum ViewState: Equatable {
         case idle
         case loading
@@ -569,8 +559,6 @@ final class ComparisonViewModel: ObservableObject {
         self.wishlistComparison = TravelComparisonResult(yours: [], shared: [], theirs: [], mode: .wishlist)
         self.allCountries = countryService.loadCountries()
     }
-
-    // MARK: - Public Methods
 
     func searchUser(yourVisits: [String: Visit]) async {
         state = .loading
@@ -638,8 +626,6 @@ final class ComparisonViewModel: ObservableObject {
         wishlistComparison = TravelComparisonResult(yours: [], shared: [], theirs: [], mode: .wishlist)
     }
 
-    // MARK: - Error Handling
-
     private func userFriendlyErrorMessage(from error: Error) -> String {
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain {
@@ -662,8 +648,6 @@ final class ComparisonViewModel: ObservableObject {
         }
         return "Failed to load user: \(error.localizedDescription)"
     }
-
-    // MARK: - Helpers
 
     private func getCountries(for countryIds: [String]) -> [Country] {
         let countryDict = Dictionary(uniqueKeysWithValues: allCountries.map { ($0.id, $0) })

--- a/WorldTrackerIOS/WorldTrackerIOS/Services/DeleteAccountView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Services/DeleteAccountView.swift
@@ -31,16 +31,15 @@ struct DeleteAccountView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
             HStack {
                 Text("Delete Account")
                     .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                 Spacer()
                 Button { dismiss() } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 26))
-                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 .buttonStyle(.plain)
                 .disabled(isDeleting)
@@ -56,14 +55,14 @@ struct DeleteAccountView: View {
                     VStack(alignment: .leading, spacing: 10) {
                         Text("THIS ACTION IS PERMANENT")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                             .tracking(0.8)
                             .padding(.horizontal, 4)
 
                         VStack(alignment: .leading, spacing: 0) {
                             Text("Deleting your account will:")
                                 .font(.system(size: 14, weight: .semibold))
-                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                                .foregroundStyle(Color.appInk)
                                 .padding(.horizontal, 16)
                                 .padding(.top, 16)
                                 .padding(.bottom, 12)
@@ -73,7 +72,7 @@ struct DeleteAccountView: View {
                             warningRow(
                                 icon: "xmark.circle.fill",
                                 iconColor: Color(hex: "#F9234D"),
-                                iconBg: Color(hex: "#FFF0F5"),
+                                iconBg: Color(hex: "#F9234D").opacity(0.12),
                                 text: "Remove all your travel data"
                             )
 
@@ -82,7 +81,7 @@ struct DeleteAccountView: View {
                             warningRow(
                                 icon: "trash.fill",
                                 iconColor: Color(hex: "#F9234D"),
-                                iconBg: Color(hex: "#FFF0F5"),
+                                iconBg: Color(hex: "#F9234D").opacity(0.12),
                                 text: "Delete your account permanently"
                             )
 
@@ -90,14 +89,14 @@ struct DeleteAccountView: View {
 
                             warningRow(
                                 icon: "exclamationmark.triangle.fill",
-                                iconColor: Color(hex: "#E6A817"),
-                                iconBg: Color(hex: "#FFF9E6"),
+                                iconColor: Color.appGold,
+                                iconBg: Color.appGold.opacity(0.12),
                                 text: "Cannot be recovered or undone"
                             )
 
                             Spacer(minLength: 4)
                         }
-                        .background(Color.white)
+                        .background(Color.appCard)
                         .clipShape(RoundedRectangle(cornerRadius: 14))
                         .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
                     }
@@ -106,7 +105,7 @@ struct DeleteAccountView: View {
                     VStack(alignment: .leading, spacing: 10) {
                         Text("VERIFY IDENTITY")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                             .tracking(0.8)
                             .padding(.horizontal, 4)
 
@@ -119,7 +118,7 @@ struct DeleteAccountView: View {
                                 }
                             }
                             .font(.system(size: 15))
-                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .foregroundStyle(Color.appInk)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
 
@@ -128,19 +127,19 @@ struct DeleteAccountView: View {
                             } label: {
                                 Image(systemName: showPassword ? "eye.fill" : "eye.slash.fill")
                                     .font(.system(size: 16))
-                                    .foregroundStyle(showPassword ? Color(hex: "#6B6B6B") : Color(hex: "#CCCCCC"))
+                                    .foregroundStyle(showPassword ? Color.appInk2 : Color.appInk3)
                             }
                             .buttonStyle(.plain)
                         }
                         .padding(.horizontal, 16)
                         .padding(.vertical, 16)
-                        .background(Color.white)
+                        .background(Color.appCard)
                         .clipShape(RoundedRectangle(cornerRadius: 14))
                         .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
 
                         Text("Enter your password to continue")
                             .font(.system(size: 12))
-                            .foregroundStyle(Color(hex: "#BBBBBB"))
+                            .foregroundStyle(Color.appInk3)
                             .padding(.horizontal, 4)
                     }
 
@@ -148,14 +147,14 @@ struct DeleteAccountView: View {
                     VStack(alignment: .leading, spacing: 10) {
                         Text("CONFIRM DELETION")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                             .tracking(0.8)
                             .padding(.horizontal, 4)
 
                         VStack(spacing: 0) {
                             TextField("Type DELETE to confirm", text: $confirmationText)
                                 .font(.system(size: 15))
-                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                                .foregroundStyle(Color.appInk)
                                 .autocorrectionDisabled()
                                 .textInputAutocapitalization(.characters)
                                 .padding(.horizontal, 16)
@@ -166,16 +165,16 @@ struct DeleteAccountView: View {
                             HStack(spacing: 8) {
                                 Image(systemName: confirmationValid ? "checkmark.circle.fill" : "info.circle.fill")
                                     .font(.system(size: 15))
-                                    .foregroundStyle(confirmationValid ? Color(hex: "#2E9E5B") : Color(hex: "#CCCCCC"))
+                                    .foregroundStyle(confirmationValid ? Color.appSuccess : Color.appInk3)
                                 Text(confirmationValid ? "Confirmed" : "Type exactly: DELETE")
                                     .font(.system(size: 13))
-                                    .foregroundStyle(confirmationValid ? Color(hex: "#2E9E5B") : Color(hex: "#9E9E9E"))
+                                    .foregroundStyle(confirmationValid ? Color.appSuccess : Color.appInk3)
                                 Spacer()
                             }
                             .padding(.horizontal, 16)
                             .padding(.vertical, 14)
                         }
-                        .background(Color.white)
+                        .background(Color.appCard)
                         .clipShape(RoundedRectangle(cornerRadius: 14))
                         .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
                     }
@@ -204,7 +203,7 @@ struct DeleteAccountView: View {
                             }
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 18)
-                            .background(isFormValid ? Color(hex: "#F9234D") : Color(hex: "#CCCCCC"))
+                            .background(isFormValid ? Color(hex: "#F9234D") : Color.appLine)
                             .clipShape(Capsule())
                         }
                         .buttonStyle(.plain)
@@ -213,7 +212,7 @@ struct DeleteAccountView: View {
                         Button { dismiss() } label: {
                             Text("Cancel")
                                 .font(.system(size: 15))
-                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                                .foregroundStyle(Color.appInk3)
                         }
                         .buttonStyle(.plain)
                         .disabled(isDeleting)
@@ -223,7 +222,7 @@ struct DeleteAccountView: View {
                 .padding(.bottom, 32)
             }
         }
-        .background(Color(hex: "#F7F7F7"))
+        .background(Color.appPaper)
     }
 
     // MARK: - Warning Row
@@ -238,7 +237,7 @@ struct DeleteAccountView: View {
             }
             Text(text)
                 .font(.system(size: 14))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
             Spacer()
         }
         .padding(.horizontal, 16)
@@ -289,10 +288,8 @@ struct DeleteAccountView: View {
             }
         } else if error.domain == "FIRFirestoreErrorDomain" {
             switch error.code {
-            case 7:
-                return "Permission error. Please try signing out and back in"
-            case 14:
-                return "Network error. Please check your connection and try again"
+            case 7:  return "Permission error. Please try signing out and back in"
+            case 14: return "Network error. Please check your connection and try again"
             default:
                 let message = error.localizedDescription.lowercased()
                 if message.contains("network") || message.contains("offline") || message.contains("connection") {

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AccountScreen.swift
@@ -100,7 +100,7 @@ struct AccountScreen: View {
                     } label: {
                         Text("DELETE ACCOUNT")
                             .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(Color(hex: "#BBBBBB"))
+                            .foregroundStyle(Color.appInk3)
                             .tracking(1.2)
                     }
                     .padding(.top, 16)
@@ -115,7 +115,7 @@ struct AccountScreen: View {
                     }
                 }
             }
-            .background(Color(hex: "#F7F7F7"))
+            .background(Color.appPaper)
             .navigationTitle("Account")
             .navigationBarTitleDisplayMode(.inline)
             .sheet(isPresented: $showingChangePassword) { ChangePasswordView() }
@@ -149,7 +149,7 @@ struct AccountScreen: View {
         VStack(spacing: 14) {
             ZStack {
                 Circle()
-                    .fill(Color(hex: "#1b1b1b"))
+                    .fill(Color.appSurface)
                     .frame(width: 80, height: 80)
                 Text(profileInitials)
                     .font(.system(size: 28, weight: .bold))
@@ -159,12 +159,12 @@ struct AccountScreen: View {
             VStack(spacing: 4) {
                 Text(authService.displayName)
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
 
                 if authService.displayName != authService.userEmail {
                     Text(authService.userEmail)
                         .font(.system(size: 13))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                 }
             }
 
@@ -180,10 +180,10 @@ struct AccountScreen: View {
     private func statPill(_ text: String) -> some View {
         Text(text)
             .font(.system(size: 13, weight: .medium))
-            .foregroundStyle(Color(hex: "#1b1b1b"))
+            .foregroundStyle(Color.appInk)
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
-            .background(Color.white)
+            .background(Color.appCard)
             .clipShape(Capsule())
             .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
     }
@@ -194,25 +194,24 @@ struct AccountScreen: View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Travel overview")
                 .font(.system(size: 17, weight: .bold))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
 
             VStack(spacing: 16) {
-                // Visited countries row
                 VStack(alignment: .leading, spacing: 10) {
                     HStack(spacing: 12) {
-                        iconCircle("scope", bg: Color(hex: "#FFF0F5"), fg: Color(hex: "#F9234D"))
+                        iconCircle("scope", bg: Color(hex: "#F9234D").opacity(0.12), fg: Color(hex: "#F9234D"))
                         Text("\(visitedCount) Countries Visited")
                             .font(.system(size: 15, weight: .bold))
-                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .foregroundStyle(Color.appInk)
                         Spacer()
                         Text(String(format: "%.1f%%", visitedPercentage))
                             .font(.system(size: 13))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                     }
                     GeometryReader { geo in
                         ZStack(alignment: .leading) {
                             RoundedRectangle(cornerRadius: 2)
-                                .fill(Color(hex: "#EEEEEE"))
+                                .fill(Color.appLine)
                                 .frame(height: 4)
                             RoundedRectangle(cornerRadius: 2)
                                 .fill(Color(hex: "#F9234D"))
@@ -224,22 +223,21 @@ struct AccountScreen: View {
 
                 Divider()
 
-                // Wishlist row
                 HStack(spacing: 12) {
-                    iconCircle("star.fill", bg: Color(hex: "#EAF6FE"), fg: Color(hex: "#4A90D9"))
+                    iconCircle("star.fill", bg: Color(hex: "#4A90D9").opacity(0.12), fg: Color(hex: "#4A90D9"))
                     VStack(alignment: .leading, spacing: 2) {
                         Text("\(wishlistCount) on Wishlist")
                             .font(.system(size: 15, weight: .bold))
-                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .foregroundStyle(Color.appInk)
                         Text("Your next destinations")
                             .font(.system(size: 13))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                     }
                     Spacer()
                 }
             }
             .padding(16)
-            .background(Color.white)
+            .background(Color.appCard)
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         }
@@ -251,18 +249,18 @@ struct AccountScreen: View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Travel highlights")
                 .font(.system(size: 17, weight: .bold))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
 
             VStack(spacing: 16) {
                 HStack(spacing: 12) {
-                    iconCircle("calendar", bg: Color(hex: "#F0FFF4"), fg: Color(hex: "#2E9E5B"))
+                    iconCircle("calendar", bg: Color.appSuccess.opacity(0.12), fg: Color.appSuccess)
                     VStack(alignment: .leading, spacing: 2) {
                         Text("\(visitedThisYear) Visited This Year")
                             .font(.system(size: 15, weight: .bold))
-                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .foregroundStyle(Color.appInk)
                         Text(visitedThisYear > 0 ? "Active traveler" : "Start your \(Calendar.current.component(.year, from: Date())) travels")
                             .font(.system(size: 13))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                     }
                     Spacer()
                 }
@@ -270,20 +268,20 @@ struct AccountScreen: View {
                 Divider()
 
                 HStack(spacing: 12) {
-                    iconCircle("trophy.fill", bg: Color(hex: "#FFF9E6"), fg: Color(hex: "#E6A817"))
+                    iconCircle("trophy.fill", bg: Color.appGold.opacity(0.12), fg: Color.appGold)
                     VStack(alignment: .leading, spacing: 2) {
                         Text("\(achievementSummary.unlocked)/\(achievementSummary.total) Achievements")
                             .font(.system(size: 15, weight: .bold))
-                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .foregroundStyle(Color.appInk)
                         Text(achievementSummary.unlocked > 0 ? "Nomad status" : "Unlock your first achievement")
                             .font(.system(size: 13))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                     }
                     Spacer()
                 }
             }
             .padding(16)
-            .background(Color.white)
+            .background(Color.appCard)
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         }
@@ -295,17 +293,17 @@ struct AccountScreen: View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Privacy")
                 .font(.system(size: 17, weight: .bold))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
 
             HStack(spacing: 12) {
-                iconCircle("person.2.fill", bg: Color(hex: "#F3F3F3"), fg: Color(hex: "#6B6B6B"))
+                iconCircle("person.2.fill", bg: Color.appInk.opacity(0.06), fg: Color.appInk2)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Travel Comparison")
                         .font(.system(size: 15, weight: .bold))
-                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .foregroundStyle(Color.appInk)
                     Text(allowComparison ? "Others can compare with you" : "Your travel data is private")
                         .font(.system(size: 13))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 Spacer()
                 Toggle("", isOn: Binding(
@@ -320,7 +318,7 @@ struct AccountScreen: View {
                 .disabled(isLoadingProfile || isSavingComparison)
             }
             .padding(16)
-            .background(Color.white)
+            .background(Color.appCard)
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         }
@@ -332,21 +330,21 @@ struct AccountScreen: View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Settings")
                 .font(.system(size: 17, weight: .bold))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
 
             Button { showingChangePassword = true } label: {
                 HStack(spacing: 12) {
-                    iconCircle("key.fill", bg: Color(hex: "#F3F3F3"), fg: Color(hex: "#6B6B6B"))
+                    iconCircle("key.fill", bg: Color.appInk.opacity(0.06), fg: Color.appInk2)
                     Text("Change Password")
                         .font(.system(size: 15, weight: .bold))
-                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .foregroundStyle(Color.appInk)
                     Spacer()
                     Image(systemName: "chevron.right")
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 .padding(16)
-                .background(Color.white)
+                .background(Color.appCard)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
             }
@@ -367,10 +365,10 @@ struct AccountScreen: View {
         } label: {
             Text("Sign Out")
                 .font(.system(size: 16, weight: .bold))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 18)
-                .background(Color.white)
+                .background(Color.appCard)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Auth/AuthScreen.swift
@@ -32,7 +32,7 @@ struct AuthScreen: View {
                     .font(.custom("Inter", size: 12))
                     .fontWeight(.bold)
                     .tracking(3.5)
-                    .foregroundStyle(.black)
+                    .foregroundStyle(Color.appInk)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .frame(height: 64)
 
@@ -41,13 +41,13 @@ struct AuthScreen: View {
                     Text(isCreatingAccount ? "Create your account." : "Track every place you've been.")
                         .font(.custom("Inter", size: 32))
                         .fontWeight(.bold)
-                        .foregroundStyle(.black)
+                        .foregroundStyle(Color.appInk)
                         .tracking(-0.5)
                         .fixedSize(horizontal: false, vertical: true)
 
                     Text("Your world, mapped.")
                         .font(.custom("Inter", size: 15))
-                        .foregroundStyle(Color(hex: "#6B6B6B"))
+                        .foregroundStyle(Color.appInk2)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 24)
@@ -65,7 +65,7 @@ struct AuthScreen: View {
                                 .autocorrectionDisabled()
                                 .padding(.horizontal, 16)
                                 .frame(height: 52)
-                                .background(Color(hex: "#F3F3F3"))
+                                .background(Color.appPaper2)
                                 .clipShape(RoundedRectangle(cornerRadius: 10))
 
                             TextField("Last Name", text: $lastName)
@@ -74,7 +74,7 @@ struct AuthScreen: View {
                                 .autocorrectionDisabled()
                                 .padding(.horizontal, 16)
                                 .frame(height: 52)
-                                .background(Color(hex: "#F3F3F3"))
+                                .background(Color.appPaper2)
                                 .clipShape(RoundedRectangle(cornerRadius: 10))
                         }
                     }
@@ -87,7 +87,7 @@ struct AuthScreen: View {
                         .autocorrectionDisabled()
                         .padding(.horizontal, 16)
                         .frame(height: 52)
-                        .background(Color(hex: "#F3F3F3"))
+                        .background(Color.appPaper2)
                         .clipShape(RoundedRectangle(cornerRadius: 10))
 
                     // Password
@@ -111,12 +111,12 @@ struct AuthScreen: View {
                         } label: {
                             Image(systemName: showPassword ? "eye" : "eye.slash")
                                 .font(.system(size: 16))
-                                .foregroundStyle(Color(hex: "#6B6B6B"))
+                                .foregroundStyle(Color.appInk2)
                         }
                         .padding(.trailing, 16)
                     }
                     .frame(height: 52)
-                    .background(Color(hex: "#F3F3F3"))
+                    .background(Color.appPaper2)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
                 .padding(.horizontal, 24)
@@ -146,7 +146,7 @@ struct AuthScreen: View {
                     }
                     .frame(maxWidth: .infinity)
                     .frame(height: 52)
-                    .background(Color.black)
+                    .background(Color.appSurface)
                     .foregroundStyle(.white)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                 }
@@ -164,12 +164,12 @@ struct AuthScreen: View {
                             if isSendingReset {
                                 ProgressView()
                                     .scaleEffect(0.75)
-                                    .tint(Color(hex: "#6B6B6B"))
+                                    .tint(Color.appInk2)
                             }
                             Text("Forgot password?")
                                 .font(.custom("Inter", size: 14))
                                 .fontWeight(.bold)
-                                .foregroundStyle(Color(hex: "#6B6B6B"))
+                                .foregroundStyle(Color.appInk2)
                         }
                     }
                     .disabled(isSendingReset || isSubmitting)
@@ -184,15 +184,15 @@ struct AuthScreen: View {
                 // MARK: - OR Divider
                 HStack(spacing: 16) {
                     Rectangle()
-                        .fill(Color(hex: "#EEEEEE"))
+                        .fill(Color.appLine)
                         .frame(height: 1)
                     Text("OR")
                         .font(.custom("Inter", size: 12))
                         .fontWeight(.bold)
-                        .foregroundStyle(Color(hex: "#6B6B6B"))
+                        .foregroundStyle(Color.appInk2)
                         .tracking(2)
                     Rectangle()
-                        .fill(Color(hex: "#EEEEEE"))
+                        .fill(Color.appLine)
                         .frame(height: 1)
                 }
                 .padding(.horizontal, 24)
@@ -206,26 +206,21 @@ struct AuthScreen: View {
                     } label: {
                         HStack(spacing: 12) {
                             if isSocialSubmitting {
-                                ProgressView().tint(.black)
+                                ProgressView().tint(Color.appInk)
                             } else {
                                 GoogleLogoView()
                             }
                             Text("Continue with Google")
                                 .font(.custom("Inter", size: 16))
                                 .fontWeight(.semibold)
-                                .foregroundStyle(.black)
+                                .foregroundStyle(Color.appInk)
                         }
                         .frame(maxWidth: .infinity)
                         .frame(height: 52)
-                        .background(Color(hex: "#F5F5F5"))
+                        .background(Color.appPaper2)
                         .clipShape(Capsule())
                     }
                     .disabled(isSocialSubmitting || isSubmitting)
-
-                    // Apple (requires paid Apple Developer account — hidden until enrolled)
-                    // Button {
-                    //     Task { await submitSocial { try await authService.signInWithApple() } }
-                    // } label: { ... }
                 }
                 .padding(.horizontal, 24)
                 .padding(.top, 24)
@@ -241,13 +236,13 @@ struct AuthScreen: View {
                 } label: {
                     Group {
                         if isCreatingAccount {
-                            Text("Already have an account? ") + Text("Sign in").fontWeight(.semibold).foregroundColor(.black)
+                            Text("Already have an account? ") + Text("Sign in").fontWeight(.semibold).foregroundColor(Color.appInk)
                         } else {
-                            Text("Don't have an account? ") + Text("Sign up").fontWeight(.semibold).foregroundColor(.black)
+                            Text("Don't have an account? ") + Text("Sign up").fontWeight(.semibold).foregroundColor(Color.appInk)
                         }
                     }
                     .font(.custom("Inter", size: 15))
-                    .foregroundStyle(Color(hex: "#6B6B6B"))
+                    .foregroundStyle(Color.appInk2)
                 }
                 .disabled(isSubmitting)
                 .padding(.top, 32)
@@ -256,7 +251,7 @@ struct AuthScreen: View {
             .frame(maxWidth: .infinity)
         }
         .scrollDismissesKeyboard(.interactively)
-        .background(Color.white)
+        .background(Color.appPaper)
     }
 
     private var isFormReady: Bool {
@@ -302,7 +297,7 @@ struct AuthScreen: View {
     private func submit() async {
         errorMessage = nil
         isSubmitting = true
-        
+
         defer {
             isSubmitting = false
         }
@@ -313,55 +308,30 @@ struct AuthScreen: View {
             } else {
                 try await authService.signIn(email: email, password: password)
             }
-            
-            // No need to manually call sync here - WorldTrackerIOSApp.handleAuthStateChange()
-            // will automatically trigger appState.handleSignIn() which includes sync
         } catch {
             withAnimation(.easeInOut(duration: 0.3)) {
                 errorMessage = friendlyErrorMessage(from: error)
             }
         }
     }
-    
-    /// Convert Firebase authentication errors to user-friendly messages
-    /// - Parameter error: The error from Firebase Auth
-    /// - Returns: A clear, actionable error message for the user
+
     private func friendlyErrorMessage(from error: Error) -> String {
         let nsError = error as NSError
-        
-        // Firebase Auth errors use domain "FIRAuthErrorDomain"
+
         if nsError.domain == "FIRAuthErrorDomain" {
             switch nsError.code {
-            // Sign In Errors
-            case 17008: // ERROR_INVALID_EMAIL
-                return "Please enter a valid email address"
-            case 17009: // ERROR_WRONG_PASSWORD
-                return "Incorrect password. Please try again"
-            case 17011: // ERROR_USER_NOT_FOUND
-                return "No account found with this email"
-            case 17012: // ERROR_USER_DISABLED
-                return "This account has been disabled"
-            case 17020: // ERROR_NETWORK_REQUEST_FAILED
-                return "Network error. Please check your internet connection"
-            
-            // Sign Up Errors
-            case 17007: // ERROR_EMAIL_ALREADY_IN_USE
-                return "An account with this email already exists"
-            case 17026: // ERROR_WEAK_PASSWORD
-                return "Password is too weak. Use at least 6 characters"
-            
-            // General Errors
-            case 17999: // ERROR_INVALID_CREDENTIAL
-                return "Invalid email or password"
-            case 17010: // ERROR_INVALID_API_KEY
-                return "Configuration error. Please contact support"
-            case 17014: // ERROR_USER_MISMATCH
-                return "Authentication error. Please try again"
-                
+            case 17008: return "Please enter a valid email address"
+            case 17009: return "Incorrect password. Please try again"
+            case 17011: return "No account found with this email"
+            case 17012: return "This account has been disabled"
+            case 17020: return "Network error. Please check your internet connection"
+            case 17007: return "An account with this email already exists"
+            case 17026: return "Password is too weak. Use at least 6 characters"
+            case 17999: return "Invalid email or password"
+            case 17010: return "Configuration error. Please contact support"
+            case 17014: return "Authentication error. Please try again"
             default:
-                // Check error message for common patterns
                 let message = nsError.localizedDescription.lowercased()
-                
                 if message.contains("malformed") || message.contains("credential") {
                     return "Invalid email or password format"
                 } else if message.contains("expired") {
@@ -375,14 +345,12 @@ struct AuthScreen: View {
                 }
             }
         }
-        
-        // For non-Firebase errors
+
         let message = nsError.localizedDescription.lowercased()
         if message.contains("network") || message.contains("internet") || message.contains("connection") {
             return "Network error. Please check your internet connection"
         }
-        
-        // Fallback to original error message
+
         return error.localizedDescription
     }
 }
@@ -391,7 +359,6 @@ struct AuthScreen: View {
 
 private struct GoogleLogoView: View {
     var body: some View {
-        // Standard 4-color Google "G" rendered as colored arc segments
         ZStack {
             ForEach(Array(googleSegments.enumerated()), id: \.offset) { _, seg in
                 Path { path in
@@ -405,9 +372,8 @@ private struct GoogleLogoView: View {
                 }
                 .fill(seg.color)
             }
-            // White inner circle to create ring effect
             Circle()
-                .fill(Color(hex: "#F5F5F5"))
+                .fill(Color.appPaper2)
                 .frame(width: 12, height: 12)
             Text("G")
                 .font(.system(size: 8, weight: .bold))
@@ -418,20 +384,17 @@ private struct GoogleLogoView: View {
 
     private struct Segment { let start: Double; let end: Double; let color: Color }
     private var googleSegments: [Segment] { [
-        Segment(start: -90, end:   0, color: Color(red: 0.259, green: 0.522, blue: 0.957)), // Blue
-        Segment(start:   0, end:  90, color: Color(red: 0.204, green: 0.659, blue: 0.325)), // Green
-        Segment(start:  90, end: 180, color: Color(red: 0.984, green: 0.737, blue: 0.020)), // Yellow
-        Segment(start: 180, end: 270, color: Color(red: 0.918, green: 0.263, blue: 0.208)), // Red
+        Segment(start: -90, end:   0, color: Color(red: 0.259, green: 0.522, blue: 0.957)),
+        Segment(start:   0, end:  90, color: Color(red: 0.204, green: 0.659, blue: 0.325)),
+        Segment(start:  90, end: 180, color: Color(red: 0.984, green: 0.737, blue: 0.020)),
+        Segment(start: 180, end: 270, color: Color(red: 0.918, green: 0.263, blue: 0.208)),
     ] }
 }
 
 // MARK: - App Logo View
 
-/// Displays the app logo with a fallback to a globe icon
 struct AppLogoView: View {
     var body: some View {
-        // Try to load the logo from Assets
-        // If "AppLogo" asset doesn't exist, show gradient globe fallback
         if let uiImage = UIImage(named: "AppLogo") {
             Image(uiImage: uiImage)
                 .resizable()
@@ -440,7 +403,6 @@ struct AppLogoView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 22.5, style: .continuous))
                 .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
         } else {
-            // Fallback: gradient globe icon
             ZStack {
                 Circle()
                     .fill(
@@ -452,7 +414,7 @@ struct AppLogoView: View {
                     )
                     .frame(width: 100, height: 100)
                     .shadow(color: .blue.opacity(0.3), radius: 8, x: 0, y: 4)
-                
+
                 Image(systemName: "globe.americas.fill")
                     .font(.system(size: 50))
                     .foregroundStyle(.white)
@@ -460,4 +422,3 @@ struct AppLogoView: View {
         }
     }
 }
-

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Countries/CountriesScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Countries/CountriesScreen.swift
@@ -17,12 +17,10 @@ struct CountriesScreen: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    // Search bar
                     searchBar
                         .padding(.horizontal, 16)
                         .padding(.top, 16)
 
-                    // Continent filter chips
                     continentChips
                         .padding(.top, 12)
 
@@ -41,7 +39,7 @@ struct CountriesScreen: View {
                 }
                 .padding(.bottom, 32)
             }
-            .background(Color(hex: "#F7F7F7"))
+            .background(Color.appPaper)
             .navigationTitle("Countries")
             .navigationBarTitleDisplayMode(.inline)
             .onAppear { vm.load() }
@@ -54,22 +52,22 @@ struct CountriesScreen: View {
         HStack(spacing: 10) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 16))
-                .foregroundStyle(Color(hex: "#6B6B6B"))
+                .foregroundStyle(Color.appInk2)
             TextField("Search countries...", text: $vm.searchText)
                 .font(.system(size: 16))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
             if !vm.searchText.isEmpty {
                 Button { vm.searchText = "" } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 16))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 .buttonStyle(.plain)
             }
         }
         .padding(.horizontal, 16)
         .frame(height: 44)
-        .background(Color(hex: "#EEEEEE"))
+        .background(Color.appPaper2)
         .clipShape(Capsule())
     }
 
@@ -95,12 +93,12 @@ struct CountriesScreen: View {
         Button(action: action) {
             Text(title)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(isSelected ? .white : Color(hex: "#6B6B6B"))
+                .foregroundStyle(isSelected ? .white : Color.appInk2)
                 .padding(.horizontal, 18)
                 .padding(.vertical, 8)
-                .background(isSelected ? Color.black : Color.white)
+                .background(isSelected ? Color.appSurface : Color.appCard)
                 .clipShape(Capsule())
-                .overlay(Capsule().stroke(isSelected ? Color.clear : Color(hex: "#E2E2E2"), lineWidth: 1))
+                .overlay(Capsule().stroke(isSelected ? Color.clear : Color.appLine, lineWidth: 1))
         }
         .buttonStyle(.plain)
     }
@@ -116,7 +114,7 @@ struct CountriesScreen: View {
 
         return Text("\(continentsWithVisit) CONTINENTS · \(totalVisited) COUNTRIES VISITED")
             .font(.system(size: 12, weight: .semibold))
-            .foregroundStyle(Color(hex: "#9E9E9E"))
+            .foregroundStyle(Color.appInk3)
             .tracking(0.5)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -153,7 +151,7 @@ struct CountriesScreen: View {
             if vm.filteredCountries.isEmpty {
                 Text("No countries match \"\(vm.searchText)\"")
                     .font(.system(size: 14))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
                     .padding(.top, 40)
                     .frame(maxWidth: .infinity)
             } else {
@@ -191,14 +189,13 @@ private struct ContinentCard: View {
         VStack(alignment: .leading, spacing: 10) {
             Text(continent.displayName)
                 .font(.system(size: 15, weight: .bold))
-                .foregroundStyle(Color.black)
+                .foregroundStyle(Color.appInk)
                 .tracking(-0.3)
 
-            // Progress bar
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
                     RoundedRectangle(cornerRadius: 2)
-                        .fill(Color(hex: "#F0F0F0"))
+                        .fill(Color.appLine)
                         .frame(height: 4)
                     RoundedRectangle(cornerRadius: 2)
                         .fill(continentColor)
@@ -214,12 +211,12 @@ private struct ContinentCard: View {
                     .tracking(0.3)
                 Text("of \(totalCount) \(totalCount == 1 ? "country" : "countries")")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
             }
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.white)
+        .background(Color.appCard)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
     }
@@ -281,28 +278,24 @@ struct ContinentCountriesView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                // Search
                 searchBar
                     .padding(.horizontal, 16)
                     .padding(.top, 16)
 
-                // Filter chips
                 filterChips
                     .padding(.top, 12)
 
-                // Summary
                 Text("\(visitedCount) of \(countries.count) countries visited in \(continent.displayName)")
                     .font(.system(size: 13))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
                     .padding(.horizontal, 20)
                     .padding(.top, 16)
                     .padding(.bottom, 8)
 
-                // Alphabetical sections
                 if filtered.isEmpty {
                     Text("No countries match your filter")
                         .font(.system(size: 14))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                         .frame(maxWidth: .infinity)
                         .padding(.top, 40)
                 } else {
@@ -311,7 +304,7 @@ struct ContinentCountriesView: View {
                             VStack(alignment: .leading, spacing: 8) {
                                 Text(group.letter)
                                     .font(.system(size: 17, weight: .black))
-                                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                                    .foregroundStyle(Color.appInk)
                                     .padding(.horizontal, 16)
 
                                 VStack(spacing: 8) {
@@ -337,7 +330,7 @@ struct ContinentCountriesView: View {
                 }
             }
         }
-        .background(Color(hex: "#F7F7F7"))
+        .background(Color.appPaper)
         .navigationTitle(continent.displayName)
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -346,22 +339,22 @@ struct ContinentCountriesView: View {
         HStack(spacing: 10) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 16))
-                .foregroundStyle(Color(hex: "#6B6B6B"))
+                .foregroundStyle(Color.appInk2)
             TextField("Search \(continent.displayName)...", text: $searchText)
                 .font(.system(size: 16))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
             if !searchText.isEmpty {
                 Button { searchText = "" } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 16))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 .buttonStyle(.plain)
             }
         }
         .padding(.horizontal, 16)
         .frame(height: 44)
-        .background(Color(hex: "#EEEEEE"))
+        .background(Color.appPaper2)
         .clipShape(Capsule())
     }
 
@@ -374,12 +367,12 @@ struct ContinentCountriesView: View {
                     } label: {
                         Text(mode.rawValue)
                             .font(.system(size: 12, weight: .bold))
-                            .foregroundStyle(filterMode == mode ? .white : .black)
+                            .foregroundStyle(filterMode == mode ? .white : Color.appInk)
                             .padding(.horizontal, 18)
                             .padding(.vertical, 8)
-                            .background(filterMode == mode ? Color.black : Color.white)
+                            .background(filterMode == mode ? Color.appSurface : Color.appCard)
                             .clipShape(Capsule())
-                            .overlay(filterMode == mode ? nil : Capsule().stroke(Color(hex: "#E2E2E2"), lineWidth: 1))
+                            .overlay(filterMode == mode ? nil : Capsule().stroke(Color.appLine, lineWidth: 1))
                     }
                     .buttonStyle(.plain)
                 }
@@ -404,7 +397,7 @@ struct CountryListRow: View {
 
             Text(country.name)
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
 
             Spacer()
 
@@ -424,11 +417,11 @@ struct CountryListRow: View {
 
             Image(systemName: "chevron.right")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(Color(hex: "#CCCCCC"))
+                .foregroundStyle(Color.appInk3)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
-        .background(Color.white)
+        .background(Color.appCard)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .shadow(color: .black.opacity(0.03), radius: 4, x: 0, y: 1)
     }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryDetailScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryDetailScreen.swift
@@ -72,7 +72,7 @@ struct CountryDetailScreen: View {
             .padding(.top, 16)
             .padding(.bottom, 40)
         }
-        .background(Color(hex: "#F7F7F7"))
+        .background(Color.appPaper)
         .navigationTitle(country.name)
         .navigationBarTitleDisplayMode(.inline)
         .onChange(of: selectedPhotoItem) { _, newValue in
@@ -91,7 +91,7 @@ struct CountryDetailScreen: View {
         }
     }
 
-    // MARK: - Hero Card (dark, Compare-style)
+    // MARK: - Hero Card (intentionally dark in both modes)
 
     private var heroCard: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -116,7 +116,7 @@ struct CountryDetailScreen: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)
-        .background(Color(hex: "#111111"))
+        .background(Color.appSurface)
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
     }
 
@@ -155,10 +155,9 @@ struct CountryDetailScreen: View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Travel Status")
                 .font(.system(size: 17, weight: .bold))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
 
             VStack(spacing: 0) {
-                // Visited row
                 Button {
                     withAnimation(.spring(response: 0.3)) {
                         isVisited.wrappedValue.toggle()
@@ -167,18 +166,17 @@ struct CountryDetailScreen: View {
                 } label: {
                     statusRow(
                         icon: "checkmark.circle.fill",
-                        iconBg: isVisited.wrappedValue ? Color(hex: "#F0FFF4") : Color(hex: "#F3F3F3"),
-                        iconFg: isVisited.wrappedValue ? Color(hex: "#2E9E5B") : Color(hex: "#CCCCCC"),
+                        iconBg: isVisited.wrappedValue ? Color.appSuccess.opacity(0.12) : Color.appInk.opacity(0.06),
+                        iconFg: isVisited.wrappedValue ? Color.appSuccess : Color.appInk3,
                         title: "Visited",
                         checked: isVisited.wrappedValue,
-                        checkColor: Color(hex: "#2E9E5B")
+                        checkColor: Color.appSuccess
                     )
                 }
                 .buttonStyle(.plain)
 
                 Divider().padding(.horizontal, 16)
 
-                // Want to visit row
                 Button {
                     withAnimation(.spring(response: 0.3)) {
                         if !isVisited.wrappedValue {
@@ -188,10 +186,10 @@ struct CountryDetailScreen: View {
                 } label: {
                     statusRow(
                         icon: "star.fill",
-                        iconBg: wantToVisitBinding.wrappedValue ? Color(hex: "#EAF6FE") : Color(hex: "#F3F3F3"),
-                        iconFg: wantToVisitBinding.wrappedValue ? Color(hex: "#4A90D9") : Color(hex: "#CCCCCC"),
+                        iconBg: wantToVisitBinding.wrappedValue ? Color(hex: "#4A90D9").opacity(0.12) : Color.appInk.opacity(0.06),
+                        iconFg: wantToVisitBinding.wrappedValue ? Color(hex: "#4A90D9") : Color.appInk3,
                         title: "Want to Visit",
-                        titleColor: isVisited.wrappedValue ? Color(hex: "#CCCCCC") : Color(hex: "#1b1b1b"),
+                        titleColor: isVisited.wrappedValue ? Color.appInk3 : Color.appInk,
                         checked: wantToVisitBinding.wrappedValue,
                         checkColor: Color(hex: "#4A90D9")
                     )
@@ -199,13 +197,12 @@ struct CountryDetailScreen: View {
                 .buttonStyle(.plain)
                 .disabled(isVisited.wrappedValue)
 
-                // Date row (visible when visited)
                 if isVisited.wrappedValue {
                     Divider().padding(.horizontal, 16)
 
                     HStack(spacing: 14) {
                         ZStack {
-                            Circle().fill(Color(hex: "#EAF4FF")).frame(width: 40, height: 40)
+                            Circle().fill(Color(hex: "#4A90D9").opacity(0.12)).frame(width: 40, height: 40)
                             Image(systemName: "calendar")
                                 .font(.system(size: 16))
                                 .foregroundStyle(Color(hex: "#4A90D9"))
@@ -213,10 +210,10 @@ struct CountryDetailScreen: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text("Visit Date")
                                 .font(.system(size: 12))
-                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                                .foregroundStyle(Color.appInk3)
                             Text(visitDate.wrappedValue, format: .dateTime.month(.wide).day().year())
                                 .font(.system(size: 15, weight: .semibold))
-                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                                .foregroundStyle(Color.appInk)
                         }
                         Spacer()
                         Button {
@@ -224,7 +221,7 @@ struct CountryDetailScreen: View {
                         } label: {
                             Text("Edit")
                                 .font(.system(size: 13, weight: .semibold))
-                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                                .foregroundStyle(Color.appInk3)
                         }
                         .buttonStyle(.plain)
                     }
@@ -240,7 +237,7 @@ struct CountryDetailScreen: View {
                     }
                 }
             }
-            .background(Color.white)
+            .background(Color.appCard)
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         }
@@ -251,7 +248,7 @@ struct CountryDetailScreen: View {
         iconBg: Color,
         iconFg: Color,
         title: String,
-        titleColor: Color = Color(hex: "#1b1b1b"),
+        titleColor: Color = Color.appInk,
         checked: Bool,
         checkColor: Color
     ) -> some View {
@@ -283,25 +280,25 @@ struct CountryDetailScreen: View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Notes")
                 .font(.system(size: 17, weight: .bold))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
 
             ZStack(alignment: .topLeading) {
                 if notes.wrappedValue.isEmpty {
                     Text("Add travel highlights, tips, and hidden gems for \(country.name)...")
                         .font(.system(size: 14))
-                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .foregroundStyle(Color.appInk3)
                         .padding(.horizontal, 16)
                         .padding(.top, 16)
                         .allowsHitTesting(false)
                 }
                 TextEditor(text: notes)
                     .font(.system(size: 14))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                     .frame(minHeight: 100)
                     .padding(12)
                     .scrollContentBackground(.hidden)
             }
-            .background(Color.white)
+            .background(Color.appCard)
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         }
@@ -314,7 +311,7 @@ struct CountryDetailScreen: View {
             HStack {
                 Text("Photos")
                     .font(.system(size: 17, weight: .bold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                 Spacer()
                 PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
                     HStack(spacing: 6) {
@@ -323,10 +320,10 @@ struct CountryDetailScreen: View {
                         Text("Add Photo")
                             .font(.system(size: 13, weight: .semibold))
                     }
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 8)
-                    .background(Color(hex: "#EEEEEE"))
+                    .background(Color.appPaper2)
                     .clipShape(Capsule())
                 }
             }
@@ -335,14 +332,14 @@ struct CountryDetailScreen: View {
                 VStack(spacing: 12) {
                     Image(systemName: "photo.stack")
                         .font(.system(size: 36))
-                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .foregroundStyle(Color.appInk3)
                     Text("No photos yet")
                         .font(.system(size: 14))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(40)
-                .background(Color.white)
+                .background(Color.appCard)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
             } else {
@@ -383,7 +380,7 @@ struct CountryDetailScreen: View {
     private func photoCell(photo: VisitPhoto, size: CGFloat, showOverlay: Bool, remaining: Int, onTap: @escaping () -> Void) -> some View {
         Button { onTap() } label: {
             ZStack {
-                Color(hex: "#EEEEEE")
+                Color.appPaper2
                 if let uiImage = UIImage(data: photo.imageData) {
                     Image(uiImage: uiImage)
                         .resizable()
@@ -536,16 +533,15 @@ struct AllPhotosSheetView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
             HStack {
                 Text("\(photos.count) Photos")
                     .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                 Spacer()
                 Button { dismiss() } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 26))
-                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 .buttonStyle(.plain)
             }
@@ -575,7 +571,7 @@ struct AllPhotosSheetView: View {
                 .padding(.bottom, 20)
             }
         }
-        .background(Color(hex: "#F7F7F7"))
+        .background(Color.appPaper)
         .fullScreenCover(item: $selectedPhoto) { photo in
             PhotoFullScreenView(photo: photo) {
                 onDelete(photo.id)
@@ -586,7 +582,7 @@ struct AllPhotosSheetView: View {
 
     private func photoThumb(_ photo: VisitPhoto) -> some View {
         ZStack {
-            Color(hex: "#EEEEEE")
+            Color.appPaper2
             if let uiImage = UIImage(data: photo.imageData) {
                 Image(uiImage: uiImage)
                     .resizable()

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -15,7 +15,7 @@ struct MapScreen: View {
 
     var onNavigateToStats: () -> Void = {}
     var onNavigateToCountries: () -> Void = {}
-    
+
     @State private var showSyncStatus = true
     @State private var selectedCountryForSheet: SelectedCountry?
     @State private var selectedCountryForDetail: Country?
@@ -26,46 +26,36 @@ struct MapScreen: View {
     @State private var allCountries: [Country] = []
     @State private var isPopupExpanded = false
     @State private var showingMemoriesSheet = false
-    
+
     enum FilterMode: String, CaseIterable {
         case all = "All"
         case visited = "Visited"
         case wishlist = "Wishlist"
     }
-    
-    // Filtered country IDs based on filter mode
+
     private var filteredVisitedCountryIDs: Set<String> {
         switch filterMode {
-        case .all, .visited:
-            return appState.visitedCountryIDs
-        case .wishlist:
-            return []
+        case .all, .visited: return appState.visitedCountryIDs
+        case .wishlist:      return []
         }
     }
-    
+
     private var filteredWantToVisitCountryIDs: Set<String> {
         switch filterMode {
-        case .all:
-            return appState.wantToVisitCountryIDs
-        case .visited:
-            return []
-        case .wishlist:
-            return appState.wantToVisitCountryIDs
+        case .all:     return appState.wantToVisitCountryIDs
+        case .visited: return []
+        case .wishlist: return appState.wantToVisitCountryIDs
         }
     }
-    
-    // Helper to determine if sync status is showing an error
+
     private var isSyncError: Bool {
-        if case .error = appState.syncStatus {
-            return true
-        }
+        if case .error = appState.syncStatus { return true }
         return false
     }
 
     var body: some View {
         NavigationStack {
             ZStack(alignment: .topLeading) {
-                // OPTIMIZATION: Isolate map in separate view to prevent parent re-renders
                 MapContainerView(
                     visitedCountryIDs: filteredVisitedCountryIDs,
                     wantToVisitCountryIDs: filteredWantToVisitCountryIDs,
@@ -78,9 +68,7 @@ struct MapScreen: View {
                 )
                 .ignoresSafeArea()
 
-                // Full overlay layout
                 VStack(spacing: 0) {
-                    // Top bar: eye button (left) + stats pill (right)
                     HStack(alignment: .center, spacing: 12) {
                         eyeButton
                         Spacer()
@@ -92,7 +80,6 @@ struct MapScreen: View {
                     .padding(.horizontal, 16)
                     .padding(.top, 8)
 
-                    // Sync status banner
                     if showSyncStatus && (showingMapUI || isSyncError) {
                         SyncStatusView(
                             status: appState.syncStatus,
@@ -110,7 +97,6 @@ struct MapScreen: View {
 
                     Spacer()
 
-                    // Bottom section
                     if showingMapUI {
                         VStack(spacing: 12) {
                             HStack(alignment: .bottom) {
@@ -128,7 +114,6 @@ struct MapScreen: View {
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                     }
 
-                    // "Where have you been?" popup — always visible
                     whereHaveYouBeenPopup
                         .padding(.bottom, 12)
                 }
@@ -178,7 +163,7 @@ struct MapScreen: View {
             }
         }
     }
-    
+
     // MARK: - Eye Button
 
     private var eyeButton: some View {
@@ -189,9 +174,9 @@ struct MapScreen: View {
         } label: {
             Image(systemName: showingMapUI ? "eye" : "eye.slash")
                 .font(.system(size: 18, weight: .medium))
-                .foregroundStyle(Color.black)
+                .foregroundStyle(Color.appInk)
                 .frame(width: 40, height: 40)
-                .background(Color.white)
+                .background(Color.appCard)
                 .clipShape(Circle())
                 .shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 3)
         }
@@ -207,7 +192,7 @@ struct MapScreen: View {
             } label: {
                 Image(systemName: "plus")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(canZoomIn ? Color.black : Color.black.opacity(0.3))
+                    .foregroundStyle(canZoomIn ? Color.appInk : Color.appInk3)
                     .frame(width: 40, height: 36)
                     .contentShape(Rectangle())
             }
@@ -215,7 +200,7 @@ struct MapScreen: View {
             .disabled(!canZoomIn)
 
             Rectangle()
-                .fill(Color(hex: "#EEEEEE"))
+                .fill(Color.appLine)
                 .frame(width: 28, height: 1)
 
             Button {
@@ -223,64 +208,47 @@ struct MapScreen: View {
             } label: {
                 Image(systemName: "minus")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(canZoomOut ? Color.black : Color.black.opacity(0.3))
+                    .foregroundStyle(canZoomOut ? Color.appInk : Color.appInk3)
                     .frame(width: 40, height: 36)
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .disabled(!canZoomOut)
         }
-        .background(Color.white)
+        .background(Color.appCard)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 3)
     }
-    
-    private var canZoomIn: Bool {
-        mapZoomLevel != .max
-    }
-    
-    private var canZoomOut: Bool {
-        mapZoomLevel != .world
-    }
-    
+
+    private var canZoomIn: Bool { mapZoomLevel != .max }
+    private var canZoomOut: Bool { mapZoomLevel != .world }
+
     private func zoomIn() {
         let generator = UIImpactFeedbackGenerator(style: .light)
         generator.prepare()
         generator.impactOccurred()
-        
         switch mapZoomLevel {
-        case .world:
-            mapZoomLevel = .continent
-        case .continent:
-            mapZoomLevel = .country
-        case .country:
-            mapZoomLevel = .city
-        case .city:
-            mapZoomLevel = .max
-        case .max:
-            break
+        case .world:     mapZoomLevel = .continent
+        case .continent: mapZoomLevel = .country
+        case .country:   mapZoomLevel = .city
+        case .city:      mapZoomLevel = .max
+        case .max:       break
         }
     }
-    
+
     private func zoomOut() {
         let generator = UIImpactFeedbackGenerator(style: .light)
         generator.prepare()
         generator.impactOccurred()
-        
         switch mapZoomLevel {
-        case .max:
-            mapZoomLevel = .city
-        case .city:
-            mapZoomLevel = .country
-        case .country:
-            mapZoomLevel = .continent
-        case .continent:
-            mapZoomLevel = .world
-        case .world:
-            break
+        case .max:       mapZoomLevel = .city
+        case .city:      mapZoomLevel = .country
+        case .country:   mapZoomLevel = .continent
+        case .continent: mapZoomLevel = .world
+        case .world:     break
         }
     }
-    
+
     // MARK: - Filter Picker
 
     private var filterPicker: some View {
@@ -294,10 +262,10 @@ struct MapScreen: View {
                 } label: {
                     Text(mode.rawValue)
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(filterMode == mode ? Color.white : Color.black)
+                        .foregroundStyle(filterMode == mode ? Color.white : Color.appInk)
                         .padding(.horizontal, 22)
                         .padding(.vertical, 10)
-                        .background(filterMode == mode ? Color.black : Color.white)
+                        .background(filterMode == mode ? Color.appSurface : Color.appCard)
                         .clipShape(Capsule())
                         .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
                 }
@@ -306,7 +274,7 @@ struct MapScreen: View {
             Spacer()
         }
     }
-    
+
     // MARK: - Stats Card
 
     private var statsCard: some View {
@@ -314,52 +282,52 @@ struct MapScreen: View {
             HStack(spacing: 4) {
                 Image(systemName: "globe")
                     .font(.system(size: 12))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
                 Text("VISITED")
                     .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
                     .tracking(0.5)
             }
 
             Rectangle()
-                .fill(Color(hex: "#E0E0E0"))
+                .fill(Color.appLine)
                 .frame(width: 1, height: 16)
 
             HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text("\(appState.visitedCountryIDs.count)")
                     .font(.system(size: 20, weight: .black))
-                    .foregroundStyle(Color.black)
+                    .foregroundStyle(Color.appInk)
                 Text("/ \(totalCountries)")
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
             }
 
             if totalCountries > 0 {
                 Rectangle()
-                    .fill(Color(hex: "#E0E0E0"))
+                    .fill(Color.appLine)
                     .frame(width: 1, height: 16)
 
                 let pct = Double(appState.visitedCountryIDs.count) / Double(totalCountries) * 100
                 Text(String(format: "%.1f%% WORLD", pct))
                     .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
                     .tracking(0.5)
             }
         }
         .padding(.vertical, 10)
         .padding(.horizontal, 14)
-        .background(Color.white)
+        .background(Color.appCard)
         .clipShape(RoundedRectangle(cornerRadius: 20))
         .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 3)
     }
-    
+
     // MARK: - Legend Card
 
     private var legendCard: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("MAP LEGEND")
                 .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(Color(hex: "#9E9E9E"))
+                .foregroundStyle(Color.appInk3)
                 .tracking(1.2)
 
             VStack(alignment: .leading, spacing: 8) {
@@ -370,7 +338,7 @@ struct MapScreen: View {
                             .frame(width: 10, height: 10)
                         Text("VISITED")
                             .font(.system(size: 10, weight: .black))
-                            .foregroundStyle(Color.black)
+                            .foregroundStyle(Color.appInk)
                             .tracking(0.5)
                     }
                 }
@@ -382,19 +350,19 @@ struct MapScreen: View {
                             .frame(width: 10, height: 10)
                         Text("WISHLIST")
                             .font(.system(size: 10, weight: .black))
-                            .foregroundStyle(Color.black)
+                            .foregroundStyle(Color.appInk)
                             .tracking(0.5)
                     }
                 }
             }
         }
         .padding(14)
-        .background(Color.white.opacity(0.9))
+        .background(Color.appCard.opacity(0.92))
         .background(.ultraThinMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .shadow(color: .black.opacity(0.12), radius: 8, x: 0, y: 4)
     }
-    
+
     // MARK: - Where Have You Been Popup
 
     private var recentVisits: [(country: Country, visit: Visit)] {
@@ -423,10 +391,9 @@ struct MapScreen: View {
     private var whereHaveYouBeenPopup: some View {
         VStack(spacing: 0) {
 
-            // MARK: Drag handle — always visible, toggles on tap/swipe
             VStack(spacing: 0) {
                 RoundedRectangle(cornerRadius: 2.5)
-                    .fill(Color(hex: "#CCCCCC"))
+                    .fill(Color.appInk3)
                     .frame(width: 36, height: 5)
                     .padding(.top, 14)
                     .padding(.bottom, 16)
@@ -434,7 +401,7 @@ struct MapScreen: View {
                 HStack {
                     Text("Where have you been?")
                         .font(.system(size: 26, weight: .bold))
-                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .foregroundStyle(Color.appInk)
                     Spacer()
                 }
                 .padding(.horizontal, 20)
@@ -458,10 +425,8 @@ struct MapScreen: View {
                     }
             )
 
-            // MARK: Expanded content
             if isPopupExpanded {
 
-                // Quick action buttons (Memories + Stats)
                 HStack(spacing: 12) {
                     quickActionButton(icon: "photo.stack.fill", label: "Memories") {
                         showingMemoriesSheet = true
@@ -474,11 +439,10 @@ struct MapScreen: View {
                 .padding(.horizontal, 20)
                 .padding(.bottom, 20)
 
-                // Recent visits header
                 HStack {
                     Text("Recent visits")
                         .font(.system(size: 17, weight: .bold))
-                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .foregroundStyle(Color.appInk)
                     Spacer()
                     Button {
                         onNavigateToCountries()
@@ -487,10 +451,10 @@ struct MapScreen: View {
                         HStack(spacing: 4) {
                             Text("See all")
                                 .font(.system(size: 14, weight: .semibold))
-                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                                .foregroundStyle(Color.appInk)
                             Image(systemName: "chevron.right")
                                 .font(.system(size: 12, weight: .semibold))
-                                .foregroundStyle(Color(hex: "#1b1b1b"))
+                                .foregroundStyle(Color.appInk)
                         }
                     }
                     .buttonStyle(.plain)
@@ -498,12 +462,11 @@ struct MapScreen: View {
                 .padding(.horizontal, 20)
                 .padding(.bottom, 12)
 
-                // Recent visits list
                 let recent = recentVisits
                 if recent.isEmpty {
                     Text("Mark countries as visited to see them here")
                         .font(.system(size: 14))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                         .frame(maxWidth: .infinity, alignment: .center)
                         .padding(.horizontal, 20)
                         .padding(.bottom, 20)
@@ -519,7 +482,7 @@ struct MapScreen: View {
                                 HStack(spacing: 14) {
                                     ZStack {
                                         Circle()
-                                            .fill(Color(hex: "#F3F3F3"))
+                                            .fill(Color.appPaper2)
                                             .frame(width: 48, height: 48)
                                         Text(item.country.flagEmoji)
                                             .font(.system(size: 24))
@@ -528,12 +491,12 @@ struct MapScreen: View {
                                     VStack(alignment: .leading, spacing: 3) {
                                         Text(item.country.name)
                                             .font(.system(size: 15, weight: .semibold))
-                                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                                            .foregroundStyle(Color.appInk)
                                         let subtitle = visitSubtitle(item.visit)
                                         if !subtitle.isEmpty {
                                             Text(subtitle)
                                                 .font(.system(size: 13))
-                                                .foregroundStyle(Color(hex: "#9E9E9E"))
+                                                .foregroundStyle(Color.appInk3)
                                         }
                                     }
 
@@ -541,7 +504,7 @@ struct MapScreen: View {
 
                                     Image(systemName: "chevron.right")
                                         .font(.system(size: 12, weight: .semibold))
-                                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                                        .foregroundStyle(Color.appInk3)
                                 }
                                 .padding(.horizontal, 20)
                                 .padding(.vertical, 14)
@@ -557,7 +520,7 @@ struct MapScreen: View {
                 }
             }
         }
-        .background(Color.white)
+        .background(Color.appCard)
         .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
         .shadow(color: .black.opacity(0.12), radius: 16, x: 0, y: -4)
         .padding(.horizontal, 16)
@@ -568,7 +531,7 @@ struct MapScreen: View {
             VStack(spacing: 10) {
                 ZStack {
                     Circle()
-                        .fill(Color(hex: "#1b1b1b"))
+                        .fill(Color.appSurface)
                         .frame(width: 44, height: 44)
                     Image(systemName: icon)
                         .font(.system(size: 18, weight: .medium))
@@ -576,59 +539,44 @@ struct MapScreen: View {
                 }
                 Text(label)
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
             }
             .frame(maxWidth: .infinity)
             .frame(height: 100)
-            .background(Color(hex: "#F3F3F3"))
+            .background(Color.appPaper2)
             .clipShape(RoundedRectangle(cornerRadius: 18))
         }
         .buttonStyle(.plain)
     }
 
     // MARK: - Data Management
-    
+
     private func handleCountryTap(countryID: String) {
         selectedCountryForSheet = SelectedCountry(id: countryID)
     }
-    
+
     private func getBitmojiAnnotations() -> [CountryBitmojiAnnotation] {
-        // Only show bitmojis at continent zoom or closer to avoid clutter
-        guard mapZoomLevel != .world else {
-            return []
-        }
-        
-        // Only show bitmojis for visited countries when in visited or all mode
-        guard filterMode == .all || filterMode == .visited else {
-            return []
-        }
-        
+        guard mapZoomLevel != .world else { return [] }
+        guard filterMode == .all || filterMode == .visited else { return [] }
+
         let countries = CountryDataService.shared.loadCountries()
-        
+
         let annotations: [CountryBitmojiAnnotation] = appState.visitedCountryIDs.compactMap { countryID -> CountryBitmojiAnnotation? in
-            guard let country = countries.first(where: { $0.id == countryID }) else {
-                return nil
-            }
-            
+            guard let country = countries.first(where: { $0.id == countryID }) else { return nil }
             let visit = appState.visit(for: countryID)
             return CountryBitmojiAnnotation(country: country, visit: visit)
         }
-        
+
         return annotations
     }
-    
+
     private func handleAuthStateChange() async {
-        guard authService.isSignedIn else {
-            return
-        }
+        guard authService.isSignedIn else { return }
         await refreshMapData()
     }
-    
+
     private func refreshMapData() async {
-        guard authService.isSignedIn else {
-            return
-        }
-        
+        guard authService.isSignedIn else { return }
         appState.refreshFromPersistence()
         await appState.syncWithCloud()
     }
@@ -641,30 +589,23 @@ struct SelectedCountry: Identifiable {
 }
 
 enum MapZoomLevel: Equatable {
-    case world      // Global view (120° span)
-    case continent  // Continental view (60° span)
-    case country    // Country view (20° span)
-    case city       // City view (5° span)
-    case max        // Maximum zoom (1° span)
-    
+    case world
+    case continent
+    case country
+    case city
+    case max
+
     var latitudeDelta: CLLocationDegrees {
         switch self {
-        case .world:
-            return 120
-        case .continent:
-            return 60
-        case .country:
-            return 20
-        case .city:
-            return 5
-        case .max:
-            return 1
+        case .world:     return 120
+        case .continent: return 60
+        case .country:   return 20
+        case .city:      return 5
+        case .max:       return 1
         }
     }
-    
-    var longitudeDelta: CLLocationDegrees {
-        return latitudeDelta
-    }
+
+    var longitudeDelta: CLLocationDegrees { latitudeDelta }
 }
 
 // MARK: - Country Quick Action Sheet
@@ -683,9 +624,8 @@ struct CountryQuickActionSheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Drag handle
             RoundedRectangle(cornerRadius: 2.5)
-                .fill(Color(hex: "#CCCCCC"))
+                .fill(Color.appInk3)
                 .frame(width: 36, height: 5)
                 .padding(.top, 12)
                 .padding(.bottom, 20)
@@ -695,35 +635,33 @@ struct CountryQuickActionSheet: View {
                 ProgressView()
                 Spacer()
             } else if let country = country {
-                // Country hero
                 VStack(spacing: 10) {
                     Text(country.flagEmoji)
                         .font(.system(size: 60))
 
                     Text(country.name)
                         .font(.system(size: 22, weight: .bold))
-                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .foregroundStyle(Color.appInk)
 
                     HStack(spacing: 8) {
                         Text(country.continent.displayName)
                             .font(.system(size: 13))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
 
                         if isVisited {
-                            statusPill("Visited", fg: Color(hex: "#2E9E5B"), bg: Color(hex: "#F0FFF4"))
+                            statusPill("Visited", fg: Color(hex: "#2E9E5B"), bg: Color.appSuccess.opacity(0.12))
                         } else if wantToVisit {
-                            statusPill("Wishlist", fg: Color(hex: "#1D8FC2"), bg: Color(hex: "#EAF6FE"))
+                            statusPill("Wishlist", fg: Color(hex: "#1D8FC2"), bg: Color(hex: "#4A90D9").opacity(0.12))
                         }
                     }
                 }
                 .padding(.bottom, 24)
 
-                // Action card
                 VStack(spacing: 0) {
                     actionRow(
                         icon: "checkmark.circle.fill",
-                        iconBg: isVisited ? Color(hex: "#F0FFF4") : Color(hex: "#F3F3F3"),
-                        iconFg: isVisited ? Color(hex: "#2E9E5B") : Color(hex: "#9E9E9E"),
+                        iconBg: isVisited ? Color.appSuccess.opacity(0.12) : Color.appInk.opacity(0.06),
+                        iconFg: isVisited ? Color.appSuccess : Color.appInk3,
                         title: isVisited ? "Mark as Not Visited" : "Mark as Visited",
                         chevron: false,
                         disabled: false
@@ -733,8 +671,8 @@ struct CountryQuickActionSheet: View {
 
                     actionRow(
                         icon: wantToVisit ? "star.fill" : "star",
-                        iconBg: wantToVisit ? Color(hex: "#EAF6FE") : Color(hex: "#F3F3F3"),
-                        iconFg: wantToVisit ? Color(hex: "#4A90D9") : Color(hex: "#9E9E9E"),
+                        iconBg: wantToVisit ? Color(hex: "#4A90D9").opacity(0.12) : Color.appInk.opacity(0.06),
+                        iconFg: wantToVisit ? Color(hex: "#4A90D9") : Color.appInk3,
                         title: wantToVisit ? "Remove from Wishlist" : "Add to Wishlist",
                         chevron: false,
                         disabled: isVisited
@@ -744,14 +682,14 @@ struct CountryQuickActionSheet: View {
 
                     actionRow(
                         icon: "arrow.right.circle.fill",
-                        iconBg: Color(hex: "#EAF4FF"),
+                        iconBg: Color(hex: "#4A90D9").opacity(0.12),
                         iconFg: Color(hex: "#4A90D9"),
                         title: "View Details",
                         chevron: true,
                         disabled: false
                     ) { onViewDetails(country) }
                 }
-                .background(Color.white)
+                .background(Color.appCard)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
                 .padding(.horizontal, 16)
@@ -762,15 +700,15 @@ struct CountryQuickActionSheet: View {
                 VStack(spacing: 10) {
                     Image(systemName: "exclamationmark.triangle")
                         .font(.system(size: 36))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                     Text("Country not found")
                         .font(.system(size: 15))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 Spacer()
             }
         }
-        .background(Color(hex: "#F7F7F7"))
+        .background(Color.appPaper)
         .task { await loadCountry() }
     }
 
@@ -795,12 +733,12 @@ struct CountryQuickActionSheet: View {
                 }
                 Text(title)
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(disabled ? Color(hex: "#CCCCCC") : Color(hex: "#1b1b1b"))
+                    .foregroundStyle(disabled ? Color.appInk3 : Color.appInk)
                 Spacer()
                 if chevron {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .foregroundStyle(Color.appInk3)
                 }
             }
             .padding(.horizontal, 16)
@@ -831,7 +769,6 @@ struct CountryQuickActionSheet: View {
 }
 
 // MARK: - Map Container (Optimization)
-/// Isolated map container to prevent unnecessary re-renders from parent view state changes
 struct MapContainerView: View {
     let visitedCountryIDs: Set<String>
     let wantToVisitCountryIDs: Set<String>
@@ -839,7 +776,7 @@ struct MapContainerView: View {
     let bitmojiAnnotations: [CountryBitmojiAnnotation]
     let onCountryTapped: ((String) -> Void)?
     let onBitmojiTapped: ((String) -> Void)?
-    
+
     var body: some View {
         VisitedCountriesMapView(
             visitedCountryIDs: visitedCountryIDs,
@@ -875,16 +812,15 @@ struct MapMemoriesSheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
             HStack {
                 Text("Memories")
                     .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                 Spacer()
                 Button { dismiss() } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 26))
-                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .foregroundStyle(Color.appInk3)
                 }
                 .buttonStyle(.plain)
             }
@@ -897,13 +833,13 @@ struct MapMemoriesSheet: View {
                 VStack(spacing: 12) {
                     Image(systemName: "photo.stack")
                         .font(.system(size: 48))
-                        .foregroundStyle(Color(hex: "#CCCCCC"))
+                        .foregroundStyle(Color.appInk3)
                     Text("No memories yet")
                         .font(.system(size: 17, weight: .semibold))
-                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .foregroundStyle(Color.appInk)
                     Text("Add photos when marking countries\nas visited to see them here")
                         .font(.system(size: 14))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                         .multilineTextAlignment(.center)
                 }
                 Spacer()
@@ -924,7 +860,7 @@ struct MapMemoriesSheet: View {
                                             .clipped()
                                     } else {
                                         Rectangle()
-                                            .fill(Color(hex: "#F3F3F3"))
+                                            .fill(Color.appPaper2)
                                             .frame(width: geo.size.width, height: geo.size.width)
                                     }
 
@@ -953,8 +889,6 @@ struct MapMemoriesSheet: View {
                 }
             }
         }
-        .background(Color(hex: "#F7F7F7"))
+        .background(Color.appPaper)
     }
 }
-
-

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Stats/StatsScreen.swift
@@ -138,7 +138,7 @@ struct StatsScreen: View {
                     Spacer().frame(height: 32)
                 }
             }
-            .background(Color(hex: "#F7F7F7"))
+            .background(Color.appPaper)
             .navigationTitle("Stats")
             .navigationBarTitleDisplayMode(.inline)
             .sheet(item: $selectedAchievement) { achievement in
@@ -158,16 +158,16 @@ struct StatsScreen: View {
             VStack(alignment: .leading, spacing: 10) {
                 Text("\(visitedCountriesCount) / \(totalCountriesCount) Countries")
                     .font(.system(size: 34, weight: .bold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                     .tracking(-0.5)
 
                 GeometryReader { geo in
                     ZStack(alignment: .leading) {
                         RoundedRectangle(cornerRadius: 2)
-                            .fill(Color(hex: "#EEEEEE"))
+                            .fill(Color.appLine)
                             .frame(height: 4)
                         RoundedRectangle(cornerRadius: 2)
-                            .fill(Color(hex: "#1b1b1b"))
+                            .fill(Color.appInk)
                             .frame(
                                 width: max(geo.size.width * (visitedPercentage / 100), visitedCountriesCount > 0 ? 6 : 0),
                                 height: 4
@@ -178,10 +178,10 @@ struct StatsScreen: View {
 
                 Text(String(format: "%.1f%% of the world", visitedPercentage))
                     .font(.system(size: 13))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
             }
             .padding(16)
-            .background(Color.white)
+            .background(Color.appCard)
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         }
@@ -211,19 +211,19 @@ struct StatsScreen: View {
         VStack(alignment: .leading, spacing: 2) {
             Text(value)
                 .font(.system(size: 40, weight: .bold))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
                 .tracking(-0.5)
             Text(label)
                 .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(Color(hex: "#1b1b1b"))
+                .foregroundStyle(Color.appInk)
                 .padding(.top, 2)
             Text(sublabel)
                 .font(.system(size: 12))
-                .foregroundStyle(Color(hex: "#9E9E9E"))
+                .foregroundStyle(Color.appInk3)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
-        .background(Color.white)
+        .background(Color.appCard)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
     }
@@ -251,13 +251,13 @@ struct StatsScreen: View {
                                         .offset(x: 2, y: -2)
                                 }
                                 .padding(10)
-                                .background(Color.white)
+                                .background(Color.appCard)
                                 .clipShape(RoundedRectangle(cornerRadius: 14))
                                 .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
 
                                 Text(country.name)
                                     .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                                    .foregroundStyle(Color.appInk)
                                     .lineLimit(1)
                             }
                             .frame(width: 70)
@@ -287,13 +287,13 @@ struct StatsScreen: View {
                                     .font(.system(size: 34))
                                     .frame(width: 50, height: 50)
                                     .padding(10)
-                                    .background(Color.white)
+                                    .background(Color.appCard)
                                     .clipShape(RoundedRectangle(cornerRadius: 14))
                                     .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
 
                                 Text(country.name)
                                     .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                                    .foregroundStyle(Color.appInk)
                                     .lineLimit(1)
                             }
                             .frame(width: 70)
@@ -320,16 +320,16 @@ struct StatsScreen: View {
                     HStack(spacing: 12) {
                         Text(continentShortName(item.continent))
                             .font(.system(size: 14, weight: .medium))
-                            .foregroundStyle(Color(hex: "#1b1b1b"))
+                            .foregroundStyle(Color.appInk)
                             .frame(width: 84, alignment: .leading)
 
                         GeometryReader { geo in
                             ZStack(alignment: .leading) {
                                 RoundedRectangle(cornerRadius: 3)
-                                    .fill(Color(hex: "#EEEEEE"))
+                                    .fill(Color.appLine)
                                     .frame(height: 6)
                                 RoundedRectangle(cornerRadius: 3)
-                                    .fill(Color(hex: "#1b1b1b"))
+                                    .fill(Color.appInk)
                                     .frame(
                                         width: max(geo.size.width * (item.percentage / 100), item.visited > 0 ? 6 : 0),
                                         height: 6
@@ -340,14 +340,14 @@ struct StatsScreen: View {
 
                         Text("\(item.visited)/\(item.total)")
                             .font(.system(size: 12))
-                            .foregroundStyle(Color(hex: "#9E9E9E"))
+                            .foregroundStyle(Color.appInk3)
                             .frame(width: 38, alignment: .trailing)
                     }
                     .padding(.horizontal, 16)
                     .padding(.vertical, 14)
                 }
             }
-            .background(Color.white)
+            .background(Color.appCard)
             .clipShape(RoundedRectangle(cornerRadius: 14))
             .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         }
@@ -407,30 +407,30 @@ struct StatsScreen: View {
                     .font(.system(size: 64))
                     .frame(maxWidth: .infinity)
                     .frame(height: 120)
-                    .background(Color(hex: "#F3F3F3"))
+                    .background(Color.appPaper2)
             }
             VStack(alignment: .leading, spacing: 4) {
                 Text(country.name)
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                 if !notes.isEmpty {
                     Text("\"\(notes)\"")
                         .font(.system(size: 13))
                         .italic()
-                        .foregroundStyle(Color(hex: "#6B6B6B"))
+                        .foregroundStyle(Color.appInk2)
                         .lineLimit(2)
                 }
                 if let date {
                     Text(date.formatted(date: .abbreviated, time: .omitted).uppercased())
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(Color(hex: "#9E9E9E"))
+                        .foregroundStyle(Color.appInk3)
                         .tracking(0.5)
                         .padding(.top, 2)
                 }
             }
             .padding(16)
         }
-        .background(Color.white)
+        .background(Color.appCard)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
         .contentShape(Rectangle())
@@ -441,7 +441,7 @@ struct StatsScreen: View {
     private func sectionLabel(_ text: String) -> some View {
         Text(text)
             .font(.system(size: 17, weight: .bold))
-            .foregroundStyle(Color(hex: "#1b1b1b"))
+            .foregroundStyle(Color.appInk)
     }
 
     private func continentShortName(_ continent: Continent) -> String {
@@ -492,12 +492,12 @@ struct StatsScreen: View {
                         .font(.system(size: 30))
                     Text(label)
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .foregroundStyle(Color.appInk)
                         .lineLimit(2)
                         .multilineTextAlignment(.center)
                 }
                 .frame(width: 90, height: 90)
-                .background(achievement.isUnlocked ? Color(hex: "#FFF9E6") : Color(hex: "#F3F3F3"))
+                .background(achievement.isUnlocked ? Color.appGoldBg : Color.appPaper2)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .shadow(color: .black.opacity(0.04), radius: 4, x: 0, y: 1)
                 .opacity(achievement.isUnlocked ? 1.0 : 0.6)
@@ -512,7 +512,6 @@ struct StatsScreen: View {
 
         var body: some View {
             VStack(spacing: 0) {
-                // Header
                 VStack(spacing: 12) {
                     Text(achievement.isUnlocked ? "🏆" : "🔒")
                         .font(.system(size: 56))
@@ -520,19 +519,18 @@ struct StatsScreen: View {
 
                     Text(achievement.badgeLabel)
                         .font(.system(size: 22, weight: .bold))
-                        .foregroundStyle(Color(hex: "#1b1b1b"))
+                        .foregroundStyle(Color.appInk)
 
                     Text(achievement.isUnlocked ? "UNLOCKED" : "LOCKED")
                         .font(.system(size: 11, weight: .bold))
                         .tracking(1.5)
-                        .foregroundStyle(achievement.isUnlocked ? Color(hex: "#1E7F4E") : Color(hex: "#9E9E9E"))
+                        .foregroundStyle(achievement.isUnlocked ? Color(hex: "#1E7F4E") : Color.appInk3)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 5)
-                        .background(achievement.isUnlocked ? Color(hex: "#1E7F4E").opacity(0.1) : Color(hex: "#F3F3F3"))
+                        .background(achievement.isUnlocked ? Color(hex: "#1E7F4E").opacity(0.1) : Color.appPaper2)
                         .clipShape(Capsule())
                 }
 
-                // Info card
                 VStack(alignment: .leading, spacing: 16) {
                     infoRow(title: "ABOUT", body: achievement.badgeDescription)
                     if !achievement.isUnlocked {
@@ -542,7 +540,7 @@ struct StatsScreen: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
-                .background(Color(hex: "#F7F7F7"))
+                .background(Color.appPaper)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .padding(.horizontal, 24)
                 .padding(.top, 24)
@@ -550,18 +548,18 @@ struct StatsScreen: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity)
-            .background(Color.white)
+            .background(Color.appCard)
         }
 
         private func infoRow(title: String, body: String) -> some View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(Color(hex: "#9E9E9E"))
+                    .foregroundStyle(Color.appInk3)
                     .tracking(0.8)
                 Text(body)
                     .font(.system(size: 15))
-                    .foregroundStyle(Color(hex: "#1b1b1b"))
+                    .foregroundStyle(Color.appInk)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }


### PR DESCRIPTION
Summary
  - Rebuilt `AppColors.swift` as an adaptive token system using
  `UIColor` dynamic providers — every color now returns a light and
  dark variant automatically based on system appearance
  - Replaced all hardcoded light-only hex values across 10 view
  files with semantic tokens (`appPaper`, `appCard`, `appInk`,
  `appSurface`, `appLine`, etc.)
  - Hero cards and CTA buttons use `appSurface` (`#111111` light /
  `#2C2C2E` dark) so they stay visually dark in both modes with
  white text readable
  - Icon circle backgrounds converted from hardcoded pastels to
  `fgColor.opacity(0.12)` for automatic adaptation

Files changed
  - `DesignSystem/AppColors.swift` — foundation of the token system
  - `App/WorldTrackerIOSApp.swift` — loading screen
  - `Views/Auth/AuthScreen.swift` + `AccountScreen.swift`
  - `Views/Countries/CountriesScreen.swift`
  - `Views/CountryDetail/CountryDetailScreen.swift`
  - `Views/Stats/StatsScreen.swift`
  - `Views/Map/MapScreen.swift`
  - `Services/ChangePasswordView.swift`, `DeleteAccountView.swift`,
  `ComparisonView.swift`

Test plan
  - [ ] Toggle system appearance (Settings → Display & Brightness)
  and verify all screens update correctly
  - [ ] Check hero cards remain dark/elevated in dark mode
  - [ ] Check text is readable in both modes
  - [ ] Verify auth flow, map, stats, country detail, comparison,
  and account settings screens