### PR TITLE
feat: achievement celebration overlay

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/project.pbxproj
+++ b/WorldTrackerIOS/WorldTrackerIOS.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		04ACF9D52F4E45E0004448FC /* WorldTrackerIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WorldTrackerIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		04ACF9D52F4E45E0004448FC /* World Tracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "World Tracker.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -66,7 +66,7 @@
 		04ACF9D62F4E45E0004448FC /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				04ACF9D52F4E45E0004448FC /* WorldTrackerIOS.app */,
+				04ACF9D52F4E45E0004448FC /* World Tracker.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -98,7 +98,7 @@
 				04CB46132FAD28CA00883B87 /* GoogleSignInSwift */,
 			);
 			productName = WorldTrackerIOS;
-			productReference = 04ACF9D52F4E45E0004448FC /* WorldTrackerIOS.app */;
+			productReference = 04ACF9D52F4E45E0004448FC /* World Tracker.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -288,6 +288,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LT76D3X9J2;
 				ENABLE_PREVIEWS = YES;
+				EXECUTABLE_NAME = WorldTrackerIOS;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WorldTrackerIOS/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "World Tracker";
@@ -302,7 +303,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				EXECUTABLE_NAME = WorldTrackerIOS;
 				PRODUCT_BUNDLE_IDENTIFIER = com.selineren.WorldTrackerIOS;
 				PRODUCT_NAME = "World Tracker";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -324,6 +324,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LT76D3X9J2;
 				ENABLE_PREVIEWS = YES;
+				EXECUTABLE_NAME = WorldTrackerIOS;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WorldTrackerIOS/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "World Tracker";
@@ -338,7 +339,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				EXECUTABLE_NAME = WorldTrackerIOS;
 				PRODUCT_BUNDLE_IDENTIFIER = com.selineren.WorldTrackerIOS;
 				PRODUCT_NAME = "World Tracker";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/App/WorldTrackerIOSApp.swift
@@ -15,6 +15,7 @@ import CoreText
 @main
 struct WorldTrackerIOSApp: App {
     @StateObject private var authService = AuthService()
+    @StateObject private var achievementNotifier = AchievementNotifier()
 
     private let container: ModelContainer
     @StateObject private var appState: AppState
@@ -86,6 +87,7 @@ struct WorldTrackerIOSApp: App {
             AuthGatedRootView()
                 .environmentObject(appState)
                 .environmentObject(authService)
+                .environmentObject(achievementNotifier)
                 .task(id: authService.authState) {
                     await handleAuthStateChange()
                 }
@@ -100,9 +102,13 @@ struct WorldTrackerIOSApp: App {
     private func handleAuthStateChange() async {
         switch authService.authState {
         case .signedIn:
+            if let userId = authService.user?.uid {
+                achievementNotifier.configure(for: userId)
+            }
             await appState.handleSignIn()
         case .signedOut:
             appState.handleSignOut()
+            achievementNotifier.reset()
         case .unknown:
             break
         }
@@ -112,40 +118,51 @@ struct WorldTrackerIOSApp: App {
 
 struct AuthGatedRootView: View {
     @EnvironmentObject private var authService: AuthService
+    @EnvironmentObject private var achievementNotifier: AchievementNotifier
 
     var body: some View {
-        Group {
-            switch authService.authState {
-            case .signedIn:
-                RootTabView()
-                    .id("signed-in-\(authService.signInCounter)")
-                    .transition(.opacity)
-                    .onAppear {
-                        #if DEBUG
-                        print("📱 Showing RootTabView (signed in)")
-                        #endif
-                    }
+        ZStack {
+            Group {
+                switch authService.authState {
+                case .signedIn:
+                    RootTabView()
+                        .id("signed-in-\(authService.signInCounter)")
+                        .transition(.opacity)
+                        .onAppear {
+                            #if DEBUG
+                            print("📱 Showing RootTabView (signed in)")
+                            #endif
+                        }
 
-            case .signedOut:
-                AuthScreen()
-                    .transition(.opacity)
-                    .onAppear {
-                        #if DEBUG
-                        print("📱 Showing AuthScreen (signed out)")
-                        #endif
-                    }
+                case .signedOut:
+                    AuthScreen()
+                        .transition(.opacity)
+                        .onAppear {
+                            #if DEBUG
+                            print("📱 Showing AuthScreen (signed out)")
+                            #endif
+                        }
 
-            case .unknown:
-                LoadingView()
-                    .transition(.opacity)
-                    .onAppear {
-                        #if DEBUG
-                        print("📱 Showing LoadingView (unknown state)")
-                        #endif
-                    }
+                case .unknown:
+                    LoadingView()
+                        .transition(.opacity)
+                        .onAppear {
+                            #if DEBUG
+                            print("📱 Showing LoadingView (unknown state)")
+                            #endif
+                        }
+                }
+            }
+            .animation(.easeInOut(duration: 0.3), value: authService.authState)
+
+            if let achievement = achievementNotifier.pendingAchievements.first {
+                AchievementCelebrationOverlay(achievement: achievement) {
+                    achievementNotifier.dismissCurrent()
+                }
+                .id(achievement.id)
+                .transition(.opacity)
             }
         }
-        .animation(.easeInOut(duration: 0.3), value: authService.authState)
     }
 }
 

--- a/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AchievementNotifier.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AchievementNotifier.swift
@@ -1,0 +1,56 @@
+//
+//  AchievementNotifier.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 13.05.2026.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class AchievementNotifier: ObservableObject {
+    @Published var pendingAchievements: [Achievement] = []
+
+    private var seenKey = "seenUnlockedAchievementIDs"
+
+    private var seenIDs: Set<String> {
+        get { Set(UserDefaults.standard.stringArray(forKey: seenKey) ?? []) }
+        set { UserDefaults.standard.set(Array(newValue), forKey: seenKey) }
+    }
+
+    /// Call once per sign-in so each account tracks its own seen achievements.
+    func configure(for userId: String) {
+        seenKey = "seenUnlockedAchievementIDs_\(userId)"
+    }
+
+    var hasPriorSeenData: Bool { !seenIDs.isEmpty }
+
+    func seed(visits: [String: Visit], countries: [Country]) {
+        let achievements = AchievementEngine.calculateAchievements(visits: visits, countries: countries)
+        let ids = Set(achievements.filter { $0.isUnlocked }.map { $0.id })
+        seenIDs = seenIDs.union(ids)
+    }
+
+    func check(visits: [String: Visit], countries: [Country]) {
+        let achievements = AchievementEngine.calculateAchievements(visits: visits, countries: countries)
+        let unlocked = achievements.filter { $0.isUnlocked }
+        let seen = seenIDs
+        let newlyUnlocked = unlocked.filter { !seen.contains($0.id) }
+        guard !newlyUnlocked.isEmpty else { return }
+        seenIDs = seen.union(Set(newlyUnlocked.map { $0.id }))
+        pendingAchievements.append(contentsOf: newlyUnlocked)
+    }
+
+    func dismissCurrent() {
+        guard !pendingAchievements.isEmpty else { return }
+        pendingAchievements.removeFirst()
+    }
+
+    /// Called on sign-out: clears pending queue and resets the key so
+    /// the next sign-in picks up the correct per-account store.
+    func reset() {
+        pendingAchievements.removeAll()
+        seenKey = "seenUnlockedAchievementIDs"
+    }
+}

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryDetailScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/CountryDetail/CountryDetailScreen.swift
@@ -16,6 +16,7 @@ struct CountryDetailScreen: View {
     @State private var showDatePicker = false
     @State private var fullScreenPhoto: VisitPhoto?
     @State private var showAllPhotos = false
+    @FocusState private var isEditingNotes: Bool
 
     // MARK: - Bindings
 
@@ -75,6 +76,13 @@ struct CountryDetailScreen: View {
         .background(Color.appPaper)
         .navigationTitle(country.name)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") { isEditingNotes = false }
+                    .fontWeight(.semibold)
+            }
+        }
         .onChange(of: selectedPhotoItem) { _, newValue in
             Task { await loadPhoto(from: newValue) }
         }
@@ -297,6 +305,7 @@ struct CountryDetailScreen: View {
                     .frame(minHeight: 100)
                     .padding(12)
                     .scrollContentBackground(.hidden)
+                    .focused($isEditingNotes)
             }
             .background(Color.appCard)
             .clipShape(RoundedRectangle(cornerRadius: 14))

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
@@ -11,9 +11,11 @@ import FirebaseAuth
 struct RootTabView: View {
     @EnvironmentObject private var authService: AuthService
     @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var achievementNotifier: AchievementNotifier
 
-    // Track selected tab - always starts on Map when view is created
     @State private var selectedTab: Tab = .map
+    @State private var hasSeededAchievements = false
+    @State private var achievementCheckTask: Task<Void, Never>?
 
     enum Tab {
         case map
@@ -75,6 +77,27 @@ struct RootTabView: View {
         .task {
             // Sync with cloud when tab view appears (user is guaranteed to be signed in)
             await appState.syncWithCloud()
+        }
+        .onChange(of: appState.visits) { _, _ in
+            let countries = CountryDataService.shared.loadCountries()
+            if !hasSeededAchievements {
+                hasSeededAchievements = true
+                if achievementNotifier.hasPriorSeenData {
+                    // Normal session: seed so existing achievements don't re-fire on launch.
+                    achievementNotifier.seed(visits: appState.visits, countries: countries)
+                    return
+                }
+                // seenIDs is empty (fresh install or debug reset): fall through to check.
+            }
+            achievementCheckTask?.cancel()
+            achievementCheckTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1.5))
+                guard !Task.isCancelled else { return }
+                achievementNotifier.check(
+                    visits: appState.visits,
+                    countries: CountryDataService.shared.loadCountries()
+                )
+            }
         }
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Shared/AchievementCelebrationView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Shared/AchievementCelebrationView.swift
@@ -1,0 +1,164 @@
+//
+//  AchievementCelebrationView.swift
+//  WorldTrackerIOS
+//
+//  Created by seren on 13.05.2026.
+//
+
+import SwiftUI
+
+// MARK: - Confetti
+
+private struct ConfettiParticle: Identifiable {
+    let id = UUID()
+    let color: Color
+    let xStart: CGFloat
+    let xEnd: CGFloat
+    let size: CGFloat
+    let isCircle: Bool
+    let delay: Double
+    let duration: Double
+    let startAngle: Double
+    let endAngle: Double
+
+    static func makeAll() -> [ConfettiParticle] {
+        let colors: [Color] = [
+            .appGold, .appVisited, .appWishlist, .appSuccess,
+            Color(hex: "#60A5FA"), Color(hex: "#F472B6"),
+            Color(hex: "#34D399"), Color(hex: "#FBBF24"), Color(hex: "#A78BFA")
+        ]
+        return (0..<60).map { _ in
+            let x = CGFloat.random(in: 0.05...0.95)
+            return ConfettiParticle(
+                color: colors.randomElement()!,
+                xStart: x,
+                xEnd: x + CGFloat.random(in: -0.1...0.1),
+                size: CGFloat.random(in: 7...14),
+                isCircle: Bool.random(),
+                delay: Double.random(in: 0...1.1),
+                duration: Double.random(in: 1.8...3.2),
+                startAngle: Double.random(in: 0...180),
+                endAngle: Double.random(in: 360...720)
+            )
+        }
+    }
+}
+
+private struct ConfettiView: View {
+    @State private var animate = false
+    @State private var particles = ConfettiParticle.makeAll()
+
+    var body: some View {
+        GeometryReader { geo in
+            ForEach(particles) { p in
+                Group {
+                    if p.isCircle {
+                        Circle()
+                            .fill(p.color)
+                            .frame(width: p.size, height: p.size)
+                    } else {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(p.color)
+                            .frame(width: p.size * 0.55, height: p.size * 1.6)
+                    }
+                }
+                .position(
+                    x: geo.size.width * (animate ? p.xEnd : p.xStart),
+                    y: animate ? geo.size.height + 60 : -30
+                )
+                .rotationEffect(.degrees(animate ? p.endAngle : p.startAngle))
+                .opacity(animate ? 0 : 1)
+                .animation(.easeIn(duration: p.duration).delay(p.delay), value: animate)
+            }
+        }
+        .allowsHitTesting(false)
+        .onAppear { animate = true }
+    }
+}
+
+// MARK: - Celebration Overlay
+
+struct AchievementCelebrationOverlay: View {
+    let achievement: Achievement
+    let onDismiss: () -> Void
+
+    @State private var isVisible = false
+
+    var body: some View {
+        ZStack {
+            Color.black
+                .opacity(isVisible ? 0.52 : 0)
+                .ignoresSafeArea()
+                .onTapGesture { handleDismiss() }
+                .animation(.easeOut(duration: 0.22), value: isVisible)
+
+            ConfettiView()
+                .ignoresSafeArea()
+                .opacity(isVisible ? 1 : 0)
+                .animation(.easeOut(duration: 0.22), value: isVisible)
+
+            // Card
+            VStack(spacing: 24) {
+                // Icon
+                ZStack {
+                    Circle()
+                        .fill(Color.appGold.opacity(0.15))
+                        .frame(width: 100, height: 100)
+                    Circle()
+                        .strokeBorder(Color.appGold.opacity(0.3), lineWidth: 1.5)
+                        .frame(width: 100, height: 100)
+                    Image(systemName: achievement.icon)
+                        .font(.system(size: 44, weight: .medium))
+                        .foregroundStyle(Color.appGold)
+                }
+
+                VStack(spacing: 10) {
+                    Text("ACHIEVEMENT UNLOCKED")
+                        .font(.custom("Inter", size: 10))
+                        .fontWeight(.bold)
+                        .tracking(2.5)
+                        .foregroundStyle(Color.appGold)
+
+                    Text(achievement.title)
+                        .font(.custom("Fraunces-Italic-VariableFont_SOFT,WONK,opsz,wght", size: 30))
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Color.appInk)
+                        .multilineTextAlignment(.center)
+
+                    Text(achievement.description)
+                        .font(.custom("Inter", size: 15))
+                        .foregroundStyle(Color.appInk2)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Button(action: handleDismiss) {
+                    Text("Awesome!")
+                        .font(.custom("Inter", size: 16))
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Color.appPaper)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(Color.appInk)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+            }
+            .padding(32)
+            .background(Color.appPaper)
+            .clipShape(RoundedRectangle(cornerRadius: 24))
+            .shadow(color: .black.opacity(0.22), radius: 32, x: 0, y: 10)
+            .padding(.horizontal, 28)
+            .scaleEffect(isVisible ? 1 : 0.82)
+            .opacity(isVisible ? 1 : 0)
+            .animation(.spring(response: 0.42, dampingFraction: 0.72), value: isVisible)
+        }
+        .onAppear { isVisible = true }
+    }
+
+    private func handleDismiss() {
+        isVisible = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            onDismiss()
+        }
+    }
+}


### PR DESCRIPTION
Summary
  - Confetti burst + modal card appears the moment an achievement is unlocked
  - `AchievementNotifier` tracks seen achievements per account (keyed by Firebase UID) so existing achievements never re-fire on launch, but a new account starts fresh
  - Celebrations are debounced 1.5s so typing a note doesn't trigger mid-keystroke
  - Added a keyboard **Done** button to the notes TextEditor

Test plan
  - [ ] Mark a country visited → "First Steps" celebration fires ~1.5s later
  - [ ] Add a note → "Memory Keeper" fires after you stop typing
  - [ ] Earn multiple achievements at once → tap "Awesome!" to cycle through each
  - [ ] Kill and relaunch → no spurious celebrations for already-earned achievements
  - [ ] Sign out, sign into a different account, earn achievements → celebrations fire correctly
  - [ ] Sign back into original account → no re-celebrations