### PR TITLE
feat: map UI polish — eye button hides all panels, centered filter pills

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -114,8 +114,11 @@ struct MapScreen: View {
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                     }
 
-                    whereHaveYouBeenPopup
-                        .padding(.bottom, 12)
+                    if showingMapUI {
+                        whereHaveYouBeenPopup
+                            .padding(.bottom, 36)
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
                 }
 
             }
@@ -253,7 +256,6 @@ struct MapScreen: View {
 
     private var filterPicker: some View {
         HStack(spacing: 8) {
-            Spacer()
             ForEach(FilterMode.allCases, id: \.self) { mode in
                 Button {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -263,7 +265,7 @@ struct MapScreen: View {
                     Text(mode.rawValue)
                         .font(.system(size: 12, weight: .bold))
                         .foregroundStyle(filterMode == mode ? Color.white : Color.appInk)
-                        .padding(.horizontal, 22)
+                        .frame(maxWidth: .infinity)
                         .padding(.vertical, 10)
                         .background(filterMode == mode ? Color.appSurface : Color.appCard)
                         .clipShape(Capsule())
@@ -271,7 +273,6 @@ struct MapScreen: View {
                 }
                 .buttonStyle(.plain)
             }
-            Spacer()
         }
     }
 


### PR DESCRIPTION
Summary
  - Wrap `whereHaveYouBeenPopup` in the `showingMapUI` guard so it hides/shows with the rest of the map UI when the eye button is toggled
  - Increase bottom padding on `whereHaveYouBeenPopup` from 12 → 36 to better anchor it above the safe area
  - Replace variable-width filter buttons with `frame(maxWidth: .infinity)` so the All / Visited / Wishlist pills are equal-width and visually balanced

Test plan
  - [ ] Tap the eye button — verify the banner, stats card, legend, zoom controls, filter pills, and where-have-you-been popup all hide/show together
  - [ ] Confirm where-have-you-been popup has appropriate bottom spacing
  - [ ] Check All / Visited / Wishlist buttons are equal width and centered