### PR TITLE
fix: prevent achievements from re-firing on sign-in and reinstall

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AchievementNotifier.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/ViewModels/AchievementNotifier.swift
@@ -24,8 +24,6 @@ final class AchievementNotifier: ObservableObject {
         seenKey = "seenUnlockedAchievementIDs_\(userId)"
     }
 
-    var hasPriorSeenData: Bool { !seenIDs.isEmpty }
-
     func seed(visits: [String: Visit], countries: [Country]) {
         let achievements = AchievementEngine.calculateAchievements(visits: visits, countries: countries)
         let ids = Set(achievements.filter { $0.isUnlocked }.map { $0.id })

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/RootTabView.swift
@@ -82,12 +82,12 @@ struct RootTabView: View {
             let countries = CountryDataService.shared.loadCountries()
             if !hasSeededAchievements {
                 hasSeededAchievements = true
-                if achievementNotifier.hasPriorSeenData {
-                    // Normal session: seed so existing achievements don't re-fire on launch.
-                    achievementNotifier.seed(visits: appState.visits, countries: countries)
-                    return
-                }
-                // seenIDs is empty (fresh install or debug reset): fall through to check.
+                // Always seed on first load so existing achievements never re-fire after
+                // reinstall or sign-in on a new device (UserDefaults cleared).
+                // For a brand-new user with no achievements this is a no-op, so they'll
+                // still see popups as they earn achievements going forward.
+                achievementNotifier.seed(visits: appState.visits, countries: countries)
+                return
             }
             achievementCheckTask?.cancel()
             achievementCheckTask = Task { @MainActor in


### PR DESCRIPTION
Summary
  - Achievements were re-showing one by one whenever a user signed back into the app or reinstalled it, because `UserDefaults` (where seen achievement IDs are stored) is cleared on reinstall
  - Fixed by always calling `seed()` on the first visit load, which silently marks all currently-unlocked achievements as already seen
  - For brand-new users with no achievements, `seed()` is a no-op — they still see popups as they earn achievements going forward
  
Root Cause
  `RootTabView` was checking `hasPriorSeenData` (whether `UserDefaults` had any seen IDs) and falling through to `check()` when empty. On reinstall or a new device, `UserDefaults` is blank, so `check()` treated every existing achievement as newly unlocked.
  
Test Plan
  - [ ] Sign out and sign back in — no achievement popups should appear
  - [ ] Delete and reinstall the app, sign in — no achievement popups should appear
  - [ ] Mark a new country after sign-in — achievement popup should still appear normally