### PR TITLE
fix: restore bitmojis after pinch zoom in from world level

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -64,7 +64,8 @@ struct MapScreen: View {
                     onCountryTapped: { countryID in
                         handleCountryTap(countryID: countryID)
                     },
-                    onBitmojiTapped: nil
+                    onBitmojiTapped: nil,
+                    onZoomLevelChanged: { mapZoomLevel = $0 }
                 )
                 .ignoresSafeArea()
 
@@ -607,6 +608,16 @@ enum MapZoomLevel: Equatable {
     }
 
     var longitudeDelta: CLLocationDegrees { latitudeDelta }
+
+    init(latitudeDelta: CLLocationDegrees) {
+        switch latitudeDelta {
+        case 90...:   self = .world
+        case 40...:   self = .continent
+        case 12.5...: self = .country
+        case 3...:    self = .city
+        default:      self = .max
+        }
+    }
 }
 
 // MARK: - Country Quick Action Sheet
@@ -777,6 +788,7 @@ struct MapContainerView: View {
     let bitmojiAnnotations: [CountryBitmojiAnnotation]
     let onCountryTapped: ((String) -> Void)?
     let onBitmojiTapped: ((String) -> Void)?
+    var onZoomLevelChanged: ((MapZoomLevel) -> Void)? = nil
 
     var body: some View {
         VisitedCountriesMapView(
@@ -785,7 +797,8 @@ struct MapContainerView: View {
             zoomLevel: $zoomLevel,
             onCountryTapped: onCountryTapped,
             bitmojiAnnotations: bitmojiAnnotations,
-            onBitmojiTapped: onBitmojiTapped
+            onBitmojiTapped: onBitmojiTapped,
+            onZoomLevelChanged: onZoomLevelChanged
         )
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
@@ -45,6 +45,7 @@ struct VisitedCountriesMapView: UIViewRepresentable {
     var onCountryTapped: ((String) -> Void)?
     var bitmojiAnnotations: [CountryBitmojiAnnotation] = []
     var onBitmojiTapped: ((String) -> Void)?
+    var onZoomLevelChanged: ((MapZoomLevel) -> Void)?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
@@ -52,7 +53,8 @@ struct VisitedCountriesMapView: UIViewRepresentable {
             wantToVisitCountryIDs: wantToVisitCountryIDs,
             zoomLevel: zoomLevel,
             onCountryTapped: onCountryTapped,
-            onBitmojiTapped: onBitmojiTapped
+            onBitmojiTapped: onBitmojiTapped,
+            onZoomLevelChanged: onZoomLevelChanged
         )
     }
 
@@ -120,6 +122,7 @@ struct VisitedCountriesMapView: UIViewRepresentable {
         // Update the callbacks
         context.coordinator.onCountryTapped = onCountryTapped
         context.coordinator.onBitmojiTapped = onBitmojiTapped
+        context.coordinator.onZoomLevelChanged = onZoomLevelChanged
         
         // Handle zoom level changes
         if context.coordinator.currentZoomLevel != zoomLevel {
@@ -212,21 +215,30 @@ struct VisitedCountriesMapView: UIViewRepresentable {
         var overlaysByCountry: [String: [MKOverlay]] = [:]
         var onCountryTapped: ((String) -> Void)?
         var onBitmojiTapped: ((String) -> Void)?
+        var onZoomLevelChanged: ((MapZoomLevel) -> Void)?
         var currentZoomLevel: MapZoomLevel
         var allOverlaysLoaded = false
-        
+
         // Cache overlay -> countryID lookups for performance
         private var overlayCountryCache: [ObjectIdentifier: String] = [:]
-        
+
         // Cache renderers to avoid recreating them on every map render
         private var rendererCache: [ObjectIdentifier: MKOverlayPathRenderer] = [:]
 
-        init(visitedCountryIDs: Set<String>, wantToVisitCountryIDs: Set<String>, zoomLevel: MapZoomLevel, onCountryTapped: ((String) -> Void)?, onBitmojiTapped: ((String) -> Void)?) {
+        init(visitedCountryIDs: Set<String>, wantToVisitCountryIDs: Set<String>, zoomLevel: MapZoomLevel, onCountryTapped: ((String) -> Void)?, onBitmojiTapped: ((String) -> Void)?, onZoomLevelChanged: ((MapZoomLevel) -> Void)? = nil) {
             self.visitedCountryIDs = visitedCountryIDs
             self.wantToVisitCountryIDs = wantToVisitCountryIDs
             self.currentZoomLevel = zoomLevel
             self.onCountryTapped = onCountryTapped
             self.onBitmojiTapped = onBitmojiTapped
+            self.onZoomLevelChanged = onZoomLevelChanged
+        }
+
+        func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
+            let newLevel = MapZoomLevel(latitudeDelta: mapView.region.span.latitudeDelta)
+            guard newLevel != currentZoomLevel else { return }
+            currentZoomLevel = newLevel
+            onZoomLevelChanged?(newLevel)
         }
         
         func updateMapOverlays(for mapView: MKMapView, toDeactivate: Set<String>, toActivate: Set<String>, toRecolor: Set<String>) {


### PR DESCRIPTION
Summary
  - Bitmojis were correctly hidden at the world zoom level, but pinching back in didn't restore them because `mapZoomLevel` was only updated by the zoom buttons — pinch gestures had no way to feed back into SwiftUI state
  - Added `mapView(_:regionDidChangeAnimated:)` delegate method to detect zoom changes from pinch and sync them back to `mapZoomLevel` via a new `onZoomLevelChanged` callback
  - Added `MapZoomLevel.init(latitudeDelta:)` to convert the map's actual span into the closest discrete zoom level (using midpoints between levels as thresholds)
  
Test plan
  - [ ] Zoom out to world level with the minus button — bitmojis disappear
  - [ ] Pinch in — bitmojis reappear without needing to tap the plus button
  - [ ] Zoom button behavior is unchanged (zoom in/out snaps correctly) 
  - [ ] Panning without changing the zoom level doesn't trigger any unexpected updates