### PR TITLE
feat: replace flat map with always-on 3D globe

### DIFF
--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/CountryMapBitmoji.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/CountryMapBitmoji.swift
@@ -8,24 +8,22 @@
 import SwiftUI
 import MapKit
 
-// MARK: - Map Annotation for Country Bitmoji
+// MARK: - Map Annotation Data Model
 
 class CountryBitmojiAnnotation: NSObject, MKAnnotation {
     let countryID: String
     let country: Country
     let visit: Visit
-    
+
     var coordinate: CLLocationCoordinate2D {
         CLLocationCoordinate2D(
             latitude: country.centroid.latitude,
             longitude: country.centroid.longitude
         )
     }
-    
-    var title: String? {
-        country.name
-    }
-    
+
+    var title: String? { country.name }
+
     init(country: Country, visit: Visit) {
         self.countryID = country.id
         self.country = country
@@ -34,132 +32,55 @@ class CountryBitmojiAnnotation: NSObject, MKAnnotation {
     }
 }
 
-// MARK: - Annotation View
+// MARK: - Pin Tip Shape
 
-class CountryBitmojiAnnotationView: MKAnnotationView {
-    static let identifier = "CountryBitmoji"
-    
-    private let containerView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .clear
-        return view
-    }()
-    
-    private let thumbnailImageView: UIImageView = {
-        let iv = UIImageView()
-        iv.contentMode = .scaleAspectFill
-        iv.clipsToBounds = true
-        iv.layer.cornerRadius = 16
-        iv.layer.borderWidth = 3.0
-        iv.layer.borderColor = UIColor.white.cgColor
-        return iv
-    }()
-    
-    private let noteIconView: UIView = {
-        let container = UIView()
-        container.backgroundColor = .white
-        container.layer.cornerRadius = 16
-        container.layer.borderWidth = 3.0
-        container.layer.borderColor = UIColor.white.cgColor
-
-        let icon = UIImageView(image: UIImage(systemName: "note.text"))
-        icon.tintColor = .darkGray
-        icon.contentMode = .scaleAspectFit
-        icon.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(icon)
-
-        NSLayoutConstraint.activate([
-            icon.centerXAnchor.constraint(equalTo: container.centerXAnchor),
-            icon.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            icon.widthAnchor.constraint(equalToConstant: 16),
-            icon.heightAnchor.constraint(equalToConstant: 16)
-        ])
-
-        return container
-    }()
-    
-    private let flagView: UIView = {
-        let container = UIView()
-        container.backgroundColor = .white
-        container.layer.cornerRadius = 16
-        container.layer.borderWidth = 3.0
-        container.layer.borderColor = UIColor.white.cgColor
-        return container
-    }()
-    
-    private let flagLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 20)
-        label.textAlignment = .center
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
-        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
-        setupViews()
+private struct PinTip: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        p.move(to: CGPoint(x: rect.midX, y: rect.maxY))
+        p.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+        p.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        p.closeSubpath()
+        return p
     }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setupViews() {
-        frame = CGSize(width: 32, height: 32).asRect
-        centerOffset = CGPoint(x: 0, y: 0) // No offset - center the circle on the location
-        
-        addSubview(containerView)
-        containerView.frame = bounds
-        
-        thumbnailImageView.frame = CGRect(x: 0, y: 0, width: 32, height: 32)
-        noteIconView.frame = CGRect(x: 0, y: 0, width: 32, height: 32)
-        flagView.frame = CGRect(x: 0, y: 0, width: 32, height: 32)
-        
-        flagView.addSubview(flagLabel)
-        NSLayoutConstraint.activate([
-            flagLabel.centerXAnchor.constraint(equalTo: flagView.centerXAnchor),
-            flagLabel.centerYAnchor.constraint(equalTo: flagView.centerYAnchor)
-        ])
-        
-        containerView.addSubview(thumbnailImageView)
-        containerView.addSubview(noteIconView)
-        containerView.addSubview(flagView)
-        
-        // Enable tap
-        isEnabled = true
-        canShowCallout = false
-    }
-    
-    func configure(with annotation: CountryBitmojiAnnotation) {
-        // Always set the flag
-        flagLabel.text = annotation.country.flagEmoji
-        
-        if let firstPhoto = annotation.visit.photos.first,
-           let image = UIImage(data: firstPhoto.imageData) {
-            // Show photo thumbnail - this is the main feature!
-            thumbnailImageView.image = image
-            thumbnailImageView.isHidden = false
-            noteIconView.isHidden = true
-            flagView.isHidden = true
-        } else if !annotation.visit.notes.isEmpty {
-            // Show note icon when no photo
-            thumbnailImageView.isHidden = true
-            noteIconView.isHidden = false
-            flagView.isHidden = true
-        } else {
-            // Show flag emoji when no content
-            thumbnailImageView.isHidden = true
-            noteIconView.isHidden = true
-            flagView.isHidden = false
+}
+
+// MARK: - SwiftUI Annotation View
+
+struct BitmojiAnnotationView: View {
+    let annotation: CountryBitmojiAnnotation
+
+    private let headSize: CGFloat = 42
+
+    var body: some View {
+        VStack(spacing: -2) {
+            // Pin head
+            ZStack {
+                Circle()
+                    .fill(Color.appCard)
+
+                if let photo = annotation.visit.photos.first,
+                   let img = UIImage(data: photo.imageData) {
+                    Image(uiImage: img)
+                        .resizable()
+                        .scaledToFill()
+                        .clipShape(Circle())
+                        .padding(2.5)
+                } else {
+                    Text(annotation.country.flagEmoji)
+                        .font(.system(size: 22))
+                }
+
+                Circle()
+                    .stroke(Color.appVisited, lineWidth: 2.5)
+            }
+            .frame(width: headSize, height: headSize)
+            .shadow(color: .black.opacity(0.22), radius: 6, x: 0, y: 3)
+
+            // Pin tip
+            PinTip()
+                .fill(Color.appVisited)
+                .frame(width: 13, height: 9)
         }
     }
 }
-
-// MARK: - Helper Extension
-
-extension CGSize {
-    var asRect: CGRect {
-        CGRect(origin: .zero, size: self)
-    }
-}
-

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/MapScreen.swift
@@ -19,7 +19,7 @@ struct MapScreen: View {
     @State private var showSyncStatus = true
     @State private var selectedCountryForSheet: SelectedCountry?
     @State private var selectedCountryForDetail: Country?
-    @State private var mapZoomLevel: MapZoomLevel = .continent
+    @State private var currentLatDelta: Double = 60
     @State private var showingMapUI = true
     @State private var filterMode: FilterMode = .all
     @State private var totalCountries: Int = 0
@@ -59,13 +59,13 @@ struct MapScreen: View {
                 MapContainerView(
                     visitedCountryIDs: filteredVisitedCountryIDs,
                     wantToVisitCountryIDs: filteredWantToVisitCountryIDs,
-                    zoomLevel: $mapZoomLevel,
+                    latDelta: $currentLatDelta,
                     bitmojiAnnotations: getBitmojiAnnotations(),
                     onCountryTapped: { countryID in
                         handleCountryTap(countryID: countryID)
                     },
                     onBitmojiTapped: nil,
-                    onZoomLevelChanged: { mapZoomLevel = $0 }
+                    onLatDeltaChanged: { currentLatDelta = $0 }
                 )
                 .ignoresSafeArea()
 
@@ -111,13 +111,13 @@ struct MapScreen: View {
                             filterPicker
                                 .padding(.horizontal, 16)
                         }
-                        .padding(.bottom, 8)
+                        .padding(.bottom, 4)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                     }
 
                     if showingMapUI {
                         whereHaveYouBeenPopup
-                            .padding(.bottom, 36)
+                            .padding(.bottom, 8)
                             .transition(.move(edge: .bottom).combined(with: .opacity))
                     }
                 }
@@ -224,33 +224,21 @@ struct MapScreen: View {
         .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 3)
     }
 
-    private var canZoomIn: Bool { mapZoomLevel != .max }
-    private var canZoomOut: Bool { mapZoomLevel != .world }
+    private var canZoomIn: Bool { currentLatDelta > 0.5 }
+    private var canZoomOut: Bool { currentLatDelta < 170 }
 
     private func zoomIn() {
         let generator = UIImpactFeedbackGenerator(style: .light)
         generator.prepare()
         generator.impactOccurred()
-        switch mapZoomLevel {
-        case .world:     mapZoomLevel = .continent
-        case .continent: mapZoomLevel = .country
-        case .country:   mapZoomLevel = .city
-        case .city:      mapZoomLevel = .max
-        case .max:       break
-        }
+        currentLatDelta = max(0.5, currentLatDelta / 2.0)
     }
 
     private func zoomOut() {
         let generator = UIImpactFeedbackGenerator(style: .light)
         generator.prepare()
         generator.impactOccurred()
-        switch mapZoomLevel {
-        case .max:       mapZoomLevel = .city
-        case .city:      mapZoomLevel = .country
-        case .country:   mapZoomLevel = .continent
-        case .continent: mapZoomLevel = .world
-        case .world:     break
-        }
+        currentLatDelta = min(180, currentLatDelta * 2.0)
     }
 
     // MARK: - Filter Picker
@@ -558,7 +546,7 @@ struct MapScreen: View {
     }
 
     private func getBitmojiAnnotations() -> [CountryBitmojiAnnotation] {
-        guard mapZoomLevel != .world else { return [] }
+        guard currentLatDelta < 90 else { return [] }
         guard filterMode == .all || filterMode == .visited else { return [] }
 
         let countries = CountryDataService.shared.loadCountries()
@@ -784,21 +772,21 @@ struct CountryQuickActionSheet: View {
 struct MapContainerView: View {
     let visitedCountryIDs: Set<String>
     let wantToVisitCountryIDs: Set<String>
-    @Binding var zoomLevel: MapZoomLevel
+    @Binding var latDelta: Double
     let bitmojiAnnotations: [CountryBitmojiAnnotation]
     let onCountryTapped: ((String) -> Void)?
     let onBitmojiTapped: ((String) -> Void)?
-    var onZoomLevelChanged: ((MapZoomLevel) -> Void)? = nil
+    var onLatDeltaChanged: ((Double) -> Void)? = nil
 
     var body: some View {
         VisitedCountriesMapView(
             visitedCountryIDs: visitedCountryIDs,
             wantToVisitCountryIDs: wantToVisitCountryIDs,
-            zoomLevel: $zoomLevel,
+            latDelta: $latDelta,
             onCountryTapped: onCountryTapped,
             bitmojiAnnotations: bitmojiAnnotations,
             onBitmojiTapped: onBitmojiTapped,
-            onZoomLevelChanged: onZoomLevelChanged
+            onLatDeltaChanged: onLatDeltaChanged
         )
     }
 }

--- a/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
+++ b/WorldTrackerIOS/WorldTrackerIOS/Views/Map/VisitedCountriesMapView.swift
@@ -15,7 +15,7 @@ extension MKCoordinateRegion {
         let regionRect = MKCoordinateRegion.mapRect(for: self)
         return regionRect.intersects(mapRect)
     }
-    
+
     static func mapRect(for region: MKCoordinateRegion) -> MKMapRect {
         let topLeft = CLLocationCoordinate2D(
             latitude: region.center.latitude + (region.span.latitudeDelta / 2),
@@ -25,10 +25,8 @@ extension MKCoordinateRegion {
             latitude: region.center.latitude - (region.span.latitudeDelta / 2),
             longitude: region.center.longitude + (region.span.longitudeDelta / 2)
         )
-        
         let topLeftPoint = MKMapPoint(topLeft)
         let bottomRightPoint = MKMapPoint(bottomRight)
-        
         return MKMapRect(
             x: min(topLeftPoint.x, bottomRightPoint.x),
             y: min(topLeftPoint.y, bottomRightPoint.y),
@@ -38,391 +36,180 @@ extension MKCoordinateRegion {
     }
 }
 
-struct VisitedCountriesMapView: UIViewRepresentable {
+private extension MKPolygon {
+    var locationCoordinates: [CLLocationCoordinate2D] {
+        var coords = [CLLocationCoordinate2D](repeating: CLLocationCoordinate2D(), count: pointCount)
+        getCoordinates(&coords, range: NSRange(location: 0, length: pointCount))
+        return coords
+    }
+}
+
+// MARK: - Data Models
+
+private struct PolygonItem: Identifiable {
+    let id: String
+    let coordinates: [CLLocationCoordinate2D]
+    let countryID: String
+}
+
+// MARK: - Map View
+
+struct VisitedCountriesMapView: View {
     let visitedCountryIDs: Set<String>
     let wantToVisitCountryIDs: Set<String>
-    @Binding var zoomLevel: MapZoomLevel
+    @Binding var latDelta: Double
     var onCountryTapped: ((String) -> Void)?
     var bitmojiAnnotations: [CountryBitmojiAnnotation] = []
     var onBitmojiTapped: ((String) -> Void)?
-    var onZoomLevelChanged: ((MapZoomLevel) -> Void)?
+    var onLatDeltaChanged: ((Double) -> Void)?
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(
-            visitedCountryIDs: visitedCountryIDs,
-            wantToVisitCountryIDs: wantToVisitCountryIDs,
-            zoomLevel: zoomLevel,
-            onCountryTapped: onCountryTapped,
-            onBitmojiTapped: onBitmojiTapped,
-            onZoomLevelChanged: onZoomLevelChanged
-        )
-    }
+    @State private var cameraPosition: MapCameraPosition = .camera(MapCamera(
+        centerCoordinate: CLLocationCoordinate2D(latitude: 20, longitude: 0),
+        distance: 20_000_000,
+        heading: 0,
+        pitch: 0
+    ))
+    @State private var overlaysByCountry: [String: [MKOverlay]] = [:]
+    @State private var polygonItems: [PolygonItem] = []
+    @State private var currentCenter = CLLocationCoordinate2D(latitude: 20, longitude: 0)
+    @State private var internalLatDelta: Double = 60
 
-    func makeUIView(context: Context) -> MKMapView {
-        let mapView = MKMapView(frame: .zero)
-        mapView.delegate = context.coordinator
-        
-        // Register annotation view class
-        mapView.register(
-            CountryBitmojiAnnotationView.self,
-            forAnnotationViewWithReuseIdentifier: CountryBitmojiAnnotationView.identifier
-        )
-        
-        // Ensure proper rendering
-        mapView.isOpaque = true
-        
-        // Enable tap gesture
-        let tapGesture = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleMapTap(_:)))
-        mapView.addGestureRecognizer(tapGesture)
-
-        if #available(iOS 16.0, *) {
-            let config = MKStandardMapConfiguration(elevationStyle: .flat, emphasisStyle: .muted)
-            mapView.preferredConfiguration = config
-        }
-
-        mapView.pointOfInterestFilter = .excludingAll
-        mapView.showsCompass = true
-        mapView.showsScale = true
-        mapView.showsTraffic = false
-
-        let region = MKCoordinateRegion(
-            center: CLLocationCoordinate2D(latitude: 20, longitude: 0),
-            span: MKCoordinateSpan(latitudeDelta: 60, longitudeDelta: 60)
-        )
-        mapView.setRegion(region, animated: false)
-
-        // Load overlays asynchronously to prevent main thread blocking
-        let coordinator = context.coordinator
-        DispatchQueue.global(qos: .userInitiated).async { [weak coordinator, weak mapView] in
-            let overlaysByCountry = CountryBoundaryService.shared.getCountryOverlays()
-
-            DispatchQueue.main.async { [weak coordinator, weak mapView] in
-                guard let coordinator = coordinator, let mapView = mapView else { return }
-                coordinator.overlaysByCountry = overlaysByCountry
-                // Only add overlays for countries that need to be colored
-                let activeCountries = coordinator.visitedCountryIDs.union(coordinator.wantToVisitCountryIDs)
-                let activeOverlays = activeCountries.flatMap { overlaysByCountry[$0] ?? [] }
-                mapView.addOverlays(activeOverlays)
-                coordinator.allOverlaysLoaded = true
+    var body: some View {
+        MapReader { proxy in
+            Map(position: $cameraPosition) {
+                ForEach(polygonItems) { item in
+                    MapPolygon(coordinates: item.coordinates)
+                        .foregroundStyle(fillColor(for: item.countryID))
+                        .stroke(strokeColor(for: item.countryID), lineWidth: lineWidth(for: item.countryID))
+                }
+                ForEach(bitmojiAnnotations, id: \.countryID) { annotation in
+                    Annotation("", coordinate: annotation.coordinate, anchor: .bottom) {
+                        BitmojiAnnotationView(annotation: annotation)
+                            .onTapGesture {
+                                onBitmojiTapped?(annotation.countryID)
+                            }
+                    }
+                }
+            }
+            .mapStyle(.hybrid(elevation: .realistic))
+            .onMapCameraChange(frequency: .onEnd) { context in
+                let actualDelta = context.region.span.latitudeDelta
+                currentCenter = context.camera.centerCoordinate
+                internalLatDelta = actualDelta
+                onLatDeltaChanged?(actualDelta)
+            }
+            .onTapGesture { location in
+                guard let coordinate = proxy.convert(location, from: .local) else { return }
+                handleMapTap(at: coordinate)
             }
         }
-
-        return mapView
-    }
-
-    func updateUIView(_ mapView: MKMapView, context: Context) {
-        // Cache old values to detect actual changes
-        let oldVisitedIDs = context.coordinator.visitedCountryIDs
-        let oldWantToVisitIDs = context.coordinator.wantToVisitCountryIDs
-        
-        // Update the coordinator's sets
-        context.coordinator.visitedCountryIDs = visitedCountryIDs
-        context.coordinator.wantToVisitCountryIDs = wantToVisitCountryIDs
-        
-        // Update the callbacks
-        context.coordinator.onCountryTapped = onCountryTapped
-        context.coordinator.onBitmojiTapped = onBitmojiTapped
-        context.coordinator.onZoomLevelChanged = onZoomLevelChanged
-        
-        // Handle zoom level changes
-        if context.coordinator.currentZoomLevel != zoomLevel {
-            context.coordinator.currentZoomLevel = zoomLevel
-            
-            // Get current center
-            let currentCenter = mapView.region.center
-            
-            // Create new region with updated zoom
-            let newRegion = MKCoordinateRegion(
+        .task {
+            let raw = await Task.detached(priority: .userInitiated) {
+                CountryBoundaryService.shared.getCountryOverlays()
+            }.value
+            overlaysByCountry = raw
+            updatePolygonItems()
+        }
+        .onChange(of: visitedCountryIDs) { _, _ in updatePolygonItems() }
+        .onChange(of: wantToVisitCountryIDs) { _, _ in updatePolygonItems() }
+        .onChange(of: latDelta) { _, newVal in
+            guard abs(newVal - internalLatDelta) > 0.01 else { return }
+            internalLatDelta = newVal
+            cameraPosition = .region(MKCoordinateRegion(
                 center: currentCenter,
-                span: MKCoordinateSpan(
-                    latitudeDelta: zoomLevel.latitudeDelta,
-                    longitudeDelta: zoomLevel.longitudeDelta
-                )
-            )
-            
-            // Animate to new zoom level
-            mapView.setRegion(newRegion, animated: true)
-        }
-        
-        // Update annotations
-        updateAnnotations(in: mapView, coordinator: context.coordinator)
-
-        if (oldVisitedIDs != visitedCountryIDs || oldWantToVisitIDs != wantToVisitCountryIDs)
-            && context.coordinator.allOverlaysLoaded {
-            let oldActive = oldVisitedIDs.union(oldWantToVisitIDs)
-            let newActive = visitedCountryIDs.union(wantToVisitCountryIDs)
-
-            let toDeactivate = oldActive.subtracting(newActive)
-            let toActivate = newActive.subtracting(oldActive)
-            // Countries that stayed colored but flipped visited↔wishlist need a color update
-            let toRecolor = oldActive.intersection(newActive).filter { id in
-                oldVisitedIDs.contains(id) != visitedCountryIDs.contains(id)
-            }
-
-            context.coordinator.updateMapOverlays(
-                for: mapView,
-                toDeactivate: toDeactivate,
-                toActivate: toActivate,
-                toRecolor: toRecolor
-            )
-        }
-    }
-    
-    private func updateAnnotations(in mapView: MKMapView, coordinator: Coordinator) {
-        let currentAnnotations = mapView.annotations.compactMap { $0 as? CountryBitmojiAnnotation }
-        
-        // Create lookup dictionaries for efficient comparison
-        let currentByID = Dictionary(uniqueKeysWithValues: currentAnnotations.map { ($0.countryID, $0) })
-        let newByID = Dictionary(uniqueKeysWithValues: bitmojiAnnotations.map { ($0.countryID, $0) })
-        
-        let currentIDs = Set(currentByID.keys)
-        let newIDs = Set(newByID.keys)
-        
-        // Only remove annotations that are no longer needed
-        let toRemove = currentAnnotations.filter { !newIDs.contains($0.countryID) }
-        if !toRemove.isEmpty {
-            mapView.removeAnnotations(toRemove)
-        }
-        
-        // Only add annotations that are new
-        let toAdd = bitmojiAnnotations.filter { !currentIDs.contains($0.countryID) }
-        if !toAdd.isEmpty {
-            mapView.addAnnotations(toAdd)
-        }
-        
-        // Update existing annotations if their visit data changed (photos/notes)
-        // This is critical when photos are added/removed but the country set stays the same
-        for countryID in currentIDs.intersection(newIDs) {
-            guard let currentAnnotation = currentByID[countryID],
-                  let newAnnotation = newByID[countryID] else { continue }
-            
-            // Check if the visit data actually changed
-            let visitChanged = currentAnnotation.visit != newAnnotation.visit
-            
-            if visitChanged {
-                // Find the existing annotation view using the OLD annotation that's on the map
-                if let annotationView = mapView.view(for: currentAnnotation) as? CountryBitmojiAnnotationView {
-                    // Reconfigure with the NEW visit data
-                    annotationView.configure(with: newAnnotation)
-                }
-            }
+                span: MKCoordinateSpan(latitudeDelta: newVal, longitudeDelta: newVal)
+            ))
         }
     }
 
-    final class Coordinator: NSObject, MKMapViewDelegate {
-        var visitedCountryIDs: Set<String>
-        var wantToVisitCountryIDs: Set<String>
-        var overlaysByCountry: [String: [MKOverlay]] = [:]
-        var onCountryTapped: ((String) -> Void)?
-        var onBitmojiTapped: ((String) -> Void)?
-        var onZoomLevelChanged: ((MapZoomLevel) -> Void)?
-        var currentZoomLevel: MapZoomLevel
-        var allOverlaysLoaded = false
+    // MARK: - Styling
 
-        // Cache overlay -> countryID lookups for performance
-        private var overlayCountryCache: [ObjectIdentifier: String] = [:]
-
-        // Cache renderers to avoid recreating them on every map render
-        private var rendererCache: [ObjectIdentifier: MKOverlayPathRenderer] = [:]
-
-        init(visitedCountryIDs: Set<String>, wantToVisitCountryIDs: Set<String>, zoomLevel: MapZoomLevel, onCountryTapped: ((String) -> Void)?, onBitmojiTapped: ((String) -> Void)?, onZoomLevelChanged: ((MapZoomLevel) -> Void)? = nil) {
-            self.visitedCountryIDs = visitedCountryIDs
-            self.wantToVisitCountryIDs = wantToVisitCountryIDs
-            self.currentZoomLevel = zoomLevel
-            self.onCountryTapped = onCountryTapped
-            self.onBitmojiTapped = onBitmojiTapped
-            self.onZoomLevelChanged = onZoomLevelChanged
+    private func fillColor(for countryID: String) -> Color {
+        if visitedCountryIDs.contains(countryID) {
+            return Color(red: 0.863, green: 0.149, blue: 0.149).opacity(0.75)
+        } else {
+            return Color(red: 0.486, green: 0.227, blue: 0.929).opacity(0.65)
         }
+    }
 
-        func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
-            let newLevel = MapZoomLevel(latitudeDelta: mapView.region.span.latitudeDelta)
-            guard newLevel != currentZoomLevel else { return }
-            currentZoomLevel = newLevel
-            onZoomLevelChanged?(newLevel)
+    private func strokeColor(for countryID: String) -> Color {
+        if visitedCountryIDs.contains(countryID) {
+            return Color(red: 0.863, green: 0.149, blue: 0.149).opacity(0.95)
+        } else {
+            return Color(red: 0.486, green: 0.227, blue: 0.929).opacity(0.9)
         }
-        
-        func updateMapOverlays(for mapView: MKMapView, toDeactivate: Set<String>, toActivate: Set<String>, toRecolor: Set<String>) {
-            // Remove overlays for countries that lost their color status
-            for countryID in toDeactivate {
-                guard let overlays = overlaysByCountry[countryID] else { continue }
-                mapView.removeOverlays(overlays)
-                for overlay in overlays {
-                    rendererCache.removeValue(forKey: ObjectIdentifier(overlay))
-                }
-            }
+    }
 
-            // Add overlays for newly colored countries (renderer will be configured on first draw)
-            for countryID in toActivate {
-                if let overlays = overlaysByCountry[countryID] {
-                    mapView.addOverlays(overlays)
-                }
-            }
+    private func lineWidth(for countryID: String) -> CGFloat {
+        visitedCountryIDs.contains(countryID) ? 1.5 : 1.2
+    }
 
-            // Update colors for countries that flipped between visited and wishlist
-            for countryID in toRecolor {
-                guard let overlays = overlaysByCountry[countryID] else { continue }
-                for overlay in overlays {
-                    let overlayID = ObjectIdentifier(overlay)
-                    if let renderer = rendererCache[overlayID] {
-                        configure(renderer: renderer, for: overlay)
-                        renderer.setNeedsDisplay()
-                    } else if let renderer = mapView.renderer(for: overlay) as? MKOverlayPathRenderer {
-                        configure(renderer: renderer, for: overlay)
-                        renderer.setNeedsDisplay()
+    // MARK: - Overlay Management
+
+    private func updatePolygonItems() {
+        let activeCountries = visitedCountryIDs.union(wantToVisitCountryIDs)
+        var items: [PolygonItem] = []
+        for countryID in activeCountries {
+            guard let overlays = overlaysByCountry[countryID] else { continue }
+            var idx = 0
+            for overlay in overlays {
+                if let polygon = overlay as? MKPolygon {
+                    items.append(PolygonItem(
+                        id: "\(countryID)_\(idx)",
+                        coordinates: polygon.locationCoordinates,
+                        countryID: countryID
+                    ))
+                    idx += 1
+                } else if let multiPolygon = overlay as? MKMultiPolygon {
+                    for subPolygon in multiPolygon.polygons {
+                        items.append(PolygonItem(
+                            id: "\(countryID)_\(idx)",
+                            coordinates: subPolygon.locationCoordinates,
+                            countryID: countryID
+                        ))
+                        idx += 1
                     }
                 }
             }
         }
-        
-        @objc func handleMapTap(_ gesture: UITapGestureRecognizer) {
-            guard let mapView = gesture.view as? MKMapView else { return }
-            
-            let point = gesture.location(in: mapView)
-            let coordinate = mapView.convert(point, toCoordinateFrom: mapView)
-            
-            // Check if we tapped on an annotation first
-            // If so, don't process country tap
-            for annotation in mapView.annotations {
-                if mapView.view(for: annotation) != nil {
-                    let annotationPoint = mapView.convert(annotation.coordinate, toPointTo: mapView)
-                    let distance = hypot(point.x - annotationPoint.x, point.y - annotationPoint.y)
-                    
-                    // If tap is within 32pt of annotation (matching the new smaller size), ignore country tap
-                    if distance < 32 {
-                        return
-                    }
-                }
-            }
-            
-            // Boundary data must be loaded before we can hit-test
-            guard !overlaysByCountry.isEmpty else { return }
-            
-            // OPTIMIZATION: Spatial filtering - only check countries near tap
-            let tapRegion = MKCoordinateRegion(
-                center: coordinate,
-                span: MKCoordinateSpan(latitudeDelta: 5, longitudeDelta: 5)
-            )
-            
-            // Check all countries with spatial filtering
-            for (countryID, overlays) in overlaysByCountry {
-                for overlay in overlays {
-                    // Quick bounds check before expensive polygon test
-                    if tapRegion.intersects(overlay.boundingMapRect) {
-                        if overlayContains(overlay, coordinate: coordinate) {
-                            onCountryTapped?(countryID)
-                            return
-                        }
-                    }
+        polygonItems = items
+    }
+
+    // MARK: - Tap Handling
+
+    private func handleMapTap(at coordinate: CLLocationCoordinate2D) {
+        guard !overlaysByCountry.isEmpty else { return }
+
+        let tapRegion = MKCoordinateRegion(
+            center: coordinate,
+            span: MKCoordinateSpan(latitudeDelta: 5, longitudeDelta: 5)
+        )
+
+        for (countryID, overlays) in overlaysByCountry {
+            for overlay in overlays {
+                guard tapRegion.intersects(overlay.boundingMapRect) else { continue }
+                if overlayContains(overlay, coordinate: coordinate) {
+                    onCountryTapped?(countryID)
+                    return
                 }
             }
         }
-        
-        private func overlayContains(_ overlay: MKOverlay, coordinate: CLLocationCoordinate2D) -> Bool {
-            if let polygon = overlay as? MKPolygon {
-                return polygonContains(polygon, coordinate: coordinate)
-            }
-            
-            if let multiPolygon = overlay as? MKMultiPolygon {
-                for polygon in multiPolygon.polygons {
-                    if polygonContains(polygon, coordinate: coordinate) {
-                        return true
-                    }
-                }
-            }
-            
-            return false
-        }
-        
-        private func polygonContains(_ polygon: MKPolygon, coordinate: CLLocationCoordinate2D) -> Bool {
-            let renderer = MKPolygonRenderer(polygon: polygon)
-            let mapPoint = MKMapPoint(coordinate)
-            let polygonPoint = renderer.point(for: mapPoint)
-            return renderer.path.contains(polygonPoint)
-        }
+    }
 
-        func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-            let overlayID = ObjectIdentifier(overlay)
-            
-            // Check cache first
-            if let cachedRenderer = rendererCache[overlayID] {
-                return cachedRenderer
-            }
-            
-            // Create new renderer
-            let renderer: MKOverlayPathRenderer
-            if let polygon = overlay as? MKPolygon {
-                renderer = MKPolygonRenderer(polygon: polygon)
-            } else if let multiPolygon = overlay as? MKMultiPolygon {
-                renderer = MKMultiPolygonRenderer(multiPolygon: multiPolygon)
-            } else {
-                return MKOverlayRenderer(overlay: overlay)
-            }
-            
-            // Configure and cache
-            configure(renderer: renderer, for: overlay)
-            rendererCache[overlayID] = renderer
-            return renderer
+    private func overlayContains(_ overlay: MKOverlay, coordinate: CLLocationCoordinate2D) -> Bool {
+        if let polygon = overlay as? MKPolygon {
+            return polygonContains(polygon, coordinate: coordinate)
         }
-        
-        func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
-            guard let bitmojiAnnotation = annotation as? CountryBitmojiAnnotation else {
-                return nil
-            }
-            
-            let view = mapView.dequeueReusableAnnotationView(
-                withIdentifier: CountryBitmojiAnnotationView.identifier,
-                for: annotation
-            ) as? CountryBitmojiAnnotationView ?? CountryBitmojiAnnotationView(
-                annotation: annotation,
-                reuseIdentifier: CountryBitmojiAnnotationView.identifier
-            )
-            
-            view.configure(with: bitmojiAnnotation)
-            return view
+        if let multiPolygon = overlay as? MKMultiPolygon {
+            return multiPolygon.polygons.contains { polygonContains($0, coordinate: coordinate) }
         }
-        
-        func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
-            // Handle bitmoji tap
-            if let annotation = view.annotation as? CountryBitmojiAnnotation {
-                onBitmojiTapped?(annotation.countryID)
-                mapView.deselectAnnotation(annotation, animated: false)
-            }
-        }
+        return false
+    }
 
-        func configure(renderer: MKOverlayPathRenderer, for overlay: MKOverlay) {
-            let countryID = countryID(for: overlay)
-
-            if let countryID, visitedCountryIDs.contains(countryID) {
-                renderer.fillColor = UIColor(red: 0.863, green: 0.149, blue: 0.149, alpha: 0.75)
-                renderer.strokeColor = UIColor(red: 0.863, green: 0.149, blue: 0.149, alpha: 0.95)
-                renderer.lineWidth = 1.5
-            } else if let countryID, wantToVisitCountryIDs.contains(countryID) {
-                renderer.fillColor = UIColor(red: 0.486, green: 0.227, blue: 0.929, alpha: 0.65)
-                renderer.strokeColor = UIColor(red: 0.486, green: 0.227, blue: 0.929, alpha: 0.9)
-                renderer.lineWidth = 1.2
-            } else {
-                renderer.fillColor = UIColor.systemGray5.withAlphaComponent(0.85)
-                renderer.strokeColor = UIColor.systemGray3.withAlphaComponent(0.7)
-                renderer.lineWidth = 0.5
-            }
-        }
-
-        private func countryID(for overlay: MKOverlay) -> String? {
-            let overlayID = ObjectIdentifier(overlay)
-            
-            // Check cache first
-            if let cached = overlayCountryCache[overlayID] {
-                return cached
-            }
-            
-            // Find and cache
-            for (countryID, overlays) in overlaysByCountry {
-                if overlays.contains(where: { $0 === overlay }) {
-                    overlayCountryCache[overlayID] = countryID
-                    return countryID
-                }
-            }
-            return nil
-        }
+    private func polygonContains(_ polygon: MKPolygon, coordinate: CLLocationCoordinate2D) -> Bool {
+        let renderer = MKPolygonRenderer(polygon: polygon)
+        let mapPoint = MKMapPoint(coordinate)
+        let polygonPoint = renderer.point(for: mapPoint)
+        return renderer.path.contains(polygonPoint)
     }
 }


### PR DESCRIPTION
Summary
  - Migrate `VisitedCountriesMapView` from `UIViewRepresentable` to SwiftUI `Map` (required for globe rendering)
  - Always render `.hybrid(elevation: .realistic)` globe — no flat map mode at any zoom level
  - Visited/wishlist countries shown as filled `MapPolygon` overlays draped on the globe surface (red = visited, purple = wishlist)
  - Replace discrete 5-level zoom enum with continuous ×2 factor zoom buttons (each tap halves or doubles the field of view)
  - Redesign bitmoji annotations as map pins (circle photo head + triangular tip) with `.bottom` anchor
  - Move bottom UI elements (popup, legend, filter) closer to the tab bar

  ## Test plan
  - [ ] App opens directly to globe view (no flat map)
  - [ ] Visited countries appear as red filled polygons on globe
  - [ ] Wishlist countries appear as purple filled polygons on globe
  - [ ] Zoom in/out buttons work continuously (each tap ×2 factor)
  - [ ] Tapping a country opens the quick action sheet
  - [ ] Bitmoji pins appear when zoomed in and hide at globe scale
  - [ ] Filter picker (All / Visited / Wishlist) correctly shows/hides polygon sets